### PR TITLE
Integrate LangGraph workflow into orchestrator run endpoint

### DIFF
--- a/src/orchestrator/main.py
+++ b/src/orchestrator/main.py
@@ -1,14 +1,67 @@
-from fastapi import FastAPI
-from typing import Dict
+"""FastAPI entrypoint for the LangGraph-based orchestrator."""
+
+import os
+from typing import Any, Dict, Optional
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+from .orchestrator import app as workflow_app
+
 
 app = FastAPI(title="NAESTRO Orchestrator")
 
+
+class TaskRequest(BaseModel):
+    """Incoming task payload."""
+
+    input: str
+    model: Optional[str] = None  # slm, nim, vllm, or auto
+
+
+class RunResponse(BaseModel):
+    """Workflow result payload."""
+
+    result: Dict[str, Any]
+
+
+def _route_model(policy: Optional[str]) -> str:
+    """Resolve the model endpoint based on policy/environment configuration."""
+
+    policy = (policy or "auto").lower()
+    base_urls = {
+        "slm": os.getenv("SLM_BASE_URL"),
+        "nim": os.getenv("NIM_BASE_URL"),
+        "vllm": os.getenv("VLLM_BASE_URL"),
+    }
+
+    if policy == "auto":
+        for key in ("slm", "vllm", "nim"):
+            if base_urls.get(key):
+                return base_urls[key]  # first configured service wins
+        raise HTTPException(status_code=500, detail="No model endpoints configured")
+
+    url = base_urls.get(policy)
+    if not url:
+        raise HTTPException(status_code=400, detail=f"Unknown model policy '{policy}'")
+    return url
+
+
 @app.get("/health")
-def health():
+def health() -> Dict[str, str]:
     return {"status": "ok"}
 
-@app.post("/run")
-def run(task: Dict):
-    # TODO: integrate LangGraph workflow (Plan -> Implement -> Verify -> Refine -> Review)
-    # TODO: route to SLM/NIM/vLLM based on policy
-    return {"ok": True, "echo": task}
+
+@app.post("/run", response_model=RunResponse)
+def run(task: TaskRequest) -> RunResponse:
+    """Execute the LangGraph workflow and return its final state."""
+
+    try:
+        model_url = _route_model(task.model)
+        state: Dict[str, Any] = {"input": task.input, "model_url": model_url}
+        result = workflow_app.invoke(state)
+        return RunResponse(result=result)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc))


### PR DESCRIPTION
## Summary
- Implement FastAPI run endpoint that executes compiled LangGraph workflow
- Route tasks across SLM/NIM/vLLM according to policy and environment
- Add request/response models and robust error handling

## Testing
- `pre-commit run --files src/orchestrator/main.py` *(fails: InvalidConfigError: .pre-commit-config.yaml is not a file)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e9da4f81c8322af9072aef19debee