### PR TITLE
Add connection pooling and error handling to RAG DB operations

### DIFF
--- a/src/rag.py
+++ b/src/rag.py
@@ -1,41 +1,100 @@
 from sentence_transformers import SentenceTransformer
-import psycopg2
+from psycopg2.pool import SimpleConnectionPool
+import logging
+import os
 
 
-model = SentenceTransformer('all-MiniLM-L12-v2')
+model = SentenceTransformer("all-MiniLM-L12-v2")
+
+logger = logging.getLogger(__name__)
+
+pool: SimpleConnectionPool | None = None
+
+
+def init_connection_pool(
+    dsn: str | None = None, minconn: int = 1, maxconn: int = 10
+) -> SimpleConnectionPool:
+    """Initialize a connection pool for PostgreSQL."""
+    global pool
+    if pool is None:
+        dsn = dsn or os.getenv("DATABASE_URL")
+        if not dsn:
+            raise ValueError("DSN required for connection pool")
+        pool = SimpleConnectionPool(minconn, maxconn, dsn)
+    return pool
+
+
+def _get_conn():
+    if pool is None:
+        raise RuntimeError("Connection pool not initialized")
+    return pool.getconn()
+
+
+def _put_conn(conn):
+    if pool:
+        pool.putconn(conn)
 
 
 def embed_text(text: str):
     return model.encode(text)
 
 
-def insert_embedding(conn, text: str, embedding):
-    with conn.cursor() as cur:
-        cur.execute(
-            "INSERT INTO embeddings (chunk_tsv, embedding) VALUES (to_tsvector('english', %s), %s)",
-            (text, embedding),
-        )
-        conn.commit()
+def insert_embedding(text: str, embedding):
+    conn = _get_conn()
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO embeddings (chunk_tsv, embedding) VALUES (to_tsvector('english', %s), %s) RETURNING id",
+                (text, embedding),
+            )
+            conn.commit()
+            inserted_id = cur.fetchone()[0]
+        return {"success": True, "id": inserted_id}
+    except Exception as exc:
+        conn.rollback()
+        logger.exception("Failed to insert embedding")
+        return {"success": False, "error": str(exc)}
+    finally:
+        _put_conn(conn)
 
 
-def hybrid_search(conn, query: str):
+def hybrid_search(query: str):
+    conn = _get_conn()
     emb = embed_text(query)
-    with conn.cursor() as cur:
-        cur.execute(
-            """
-            SELECT * FROM embeddings
-            WHERE chunk_tsv @@ plainto_tsquery(%s)
-            ORDER BY embedding <-> %s LIMIT 50;
-            """,
-            (query, emb),
-        )
-        return cur.fetchall()
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT * FROM embeddings
+                WHERE chunk_tsv @@ plainto_tsquery(%s)
+                ORDER BY embedding <-> %s LIMIT 50;
+                """,
+                (query, emb),
+            )
+            rows = cur.fetchall()
+        return {"success": True, "rows": rows}
+    except Exception as exc:
+        conn.rollback()
+        logger.exception("Failed to perform hybrid search")
+        return {"success": False, "error": str(exc)}
+    finally:
+        _put_conn(conn)
 
 
-def update_feedback(conn, id: int, boost: float = 0.1):
-    with conn.cursor() as cur:
-        cur.execute(
-            "UPDATE embeddings SET feedback_boost = feedback_boost + %s WHERE id = %s",
-            (boost, id),
-        )
-        conn.commit()
+def update_feedback(id: int, boost: float = 0.1):
+    conn = _get_conn()
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "UPDATE embeddings SET feedback_boost = feedback_boost + %s WHERE id = %s",
+                (boost, id),
+            )
+            conn.commit()
+            updated = cur.rowcount
+        return {"success": True, "updated": updated}
+    except Exception as exc:
+        conn.rollback()
+        logger.exception("Failed to update feedback")
+        return {"success": False, "error": str(exc)}
+    finally:
+        _put_conn(conn)


### PR DESCRIPTION
## Summary
- introduce a simple connection pool with helper functions
- wrap insert, search, and feedback updates in try/except with rollbacks and structured results

## Testing
- `pre-commit run --files src/rag.py` *(fails: .pre-commit-config.yaml is not a file)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ea16c5c5883228fd678cbdffe9007