### PR TITLE
Enhance pin-resources script with checks and parameterization

### DIFF
--- a/hardware/pin-resources.sh
+++ b/hardware/pin-resources.sh
@@ -1,14 +1,38 @@
 #!/bin/bash
 # Pin processes to specific CPU cores and NUMA nodes
-echo "Pinning FastAPI gateway processes (uvicorn) to CPUs 0-7"
-pgrep uvicorn | xargs -n 1 -I{} taskset -cp 0-7 {}
-echo "Pinning Postgres (pgvector) to CPUs 8-15"
-pgrep postgres | xargs -n 1 -I{} taskset -cp 8-15 {}
+FASTAPI_CPUS=${1:-0-7}
+POSTGRES_CPUS=${2:-8-15}
+IRQ=${3:-96}
+IRQ_MASK=${4:-2}
+
+status=0
+
+echo "Pinning FastAPI gateway processes (uvicorn) to CPUs ${FASTAPI_CPUS}"
+uvicorn_pids=$(pgrep uvicorn)
+if [ -n "$uvicorn_pids" ]; then
+  echo "$uvicorn_pids" | xargs -n 1 -I{} taskset -cp "${FASTAPI_CPUS}" {}
+else
+  echo "No uvicorn processes found" >&2
+  status=1
+fi
+
+echo "Pinning Postgres (pgvector) to CPUs ${POSTGRES_CPUS}"
+postgres_pids=$(pgrep postgres)
+if [ -n "$postgres_pids" ]; then
+  echo "$postgres_pids" | xargs -n 1 -I{} taskset -cp "${POSTGRES_CPUS}" {}
+else
+  echo "No postgres processes found" >&2
+  status=1
+fi
 
 # Example: Set NIC interrupt affinity (replace IRQ number as appropriate)
-IRQ=96
-if [ -f /proc/irq/$IRQ/smp_affinity ]; then
+if [ -f /proc/irq/"$IRQ"/smp_affinity ]; then
   echo "Setting IRQ affinity for $IRQ"
-  echo 2 > /proc/irq/$IRQ/smp_affinity
+  echo "$IRQ_MASK" > /proc/irq/"$IRQ"/smp_affinity
+else
+  echo "IRQ $IRQ not found" >&2
+  status=1
 fi
+
+exit $status
 


### PR DESCRIPTION
## Summary
- verify pgrep finds processes before applying taskset
- add exit codes and parameterization for CPU ranges and IRQ

## Testing
- `bash -n hardware/pin-resources.sh`
- `shellcheck hardware/pin-resources.sh`


------
https://chatgpt.com/codex/tasks/task_e_689ea2a033b88322b3ca1dd33cf9ec4f