### PR TITLE
Add negative path and calibration test coverage

### DIFF
--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -41,3 +41,14 @@ def test_orchestrate(monkeypatch):
     resp = client.post("/orchestrate", json={"task": "demo"})
     assert resp.status_code == 200
     assert resp.json() == response_payload
+
+def test_orchestrate_missing_body():
+    client = TestClient(app)
+    resp = client.post("/orchestrate")
+    assert resp.status_code == 422
+
+
+def test_unknown_route():
+    client = TestClient(app)
+    resp = client.get("/doesnotexist")
+    assert resp.status_code == 404

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -40,3 +40,16 @@ def test_run_unknown_policy(orch_module):
     client = TestClient(app)
     resp = client.post("/run", json={"input": "x", "model": "unknown"})
     assert resp.status_code == 400
+
+def test_run_missing_input(orch_module):
+    app = orch_module.app
+    client = TestClient(app)
+    resp = client.post("/run", json={"model": "slm"})
+    assert resp.status_code == 422
+
+
+def test_unknown_route(orch_module):
+    app = orch_module.app
+    client = TestClient(app)
+    resp = client.get("/doesnotexist")
+    assert resp.status_code == 404

--- a/tests/test_pii_calibrate.py
+++ b/tests/test_pii_calibrate.py
@@ -1,0 +1,32 @@
+import builtins
+import importlib
+import io
+import json
+import string
+
+import pytest
+
+
+def test_entropy_thresholds_and_flags(monkeypatch):
+    # Prepare sample dataset with high and low entropy texts
+    high_entropy_text = string.ascii_lowercase + string.digits  # 36 unique chars
+    low_entropy_text = "a" * 20  # Single repeated char
+    sample_data = [
+        {"text": high_entropy_text, "label": "key"},
+        {"text": low_entropy_text, "label": "email"},
+    ]
+
+    original_open = builtins.open
+
+    def fake_open(path, *args, **kwargs):
+        if str(path).endswith("pii_calib_set.json"):
+            return io.StringIO(json.dumps(sample_data))
+        return original_open(path, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", fake_open)
+    module = importlib.reload(importlib.import_module("jobs.pii_calibrate"))
+
+    assert module.calculate_shannon_entropy(high_entropy_text) > module.thresholds["high"]
+    assert module.calculate_shannon_entropy(low_entropy_text) < module.thresholds["low"]
+    assert module.data[0]["flag"] == "high"
+    assert module.data[1]["flag"] == "low"

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -175,3 +175,22 @@ def test_update_feedback(rag):
     result = rag.update_feedback(1, 0.2)
     assert result == {"success": True, "updated": 1}
     assert rag.pool.conn.committed
+
+def test_insert_embedding_connection_failure(rag, monkeypatch):
+    def raise_conn():
+        raise RuntimeError("no connection")
+
+    monkeypatch.setattr(rag, "_get_conn", raise_conn)
+    with pytest.raises(RuntimeError):
+        rag.insert_embedding("text", [0.1])
+
+
+def test_hybrid_search_invalid_input(rag, monkeypatch):
+    monkeypatch.setattr(rag, "_get_conn", lambda: object())
+
+    def bad_embed(text):
+        raise ValueError("invalid text")
+
+    monkeypatch.setattr(rag, "embed_text", bad_embed)
+    with pytest.raises(ValueError):
+        rag.hybrid_search(None)


### PR DESCRIPTION
## Summary
- test Shannon entropy thresholds and flag assignment in `pii_calibrate`
- add RAG tests for connection failures and invalid inputs
- cover gateway and orchestrator negative routes and payloads

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ea977d7a08322b0db8cbcd09d80fd