### PR TITLE
Validate PII calibration dataset distribution

### DIFF
--- a/docs/pii_calibration.md
+++ b/docs/pii_calibration.md
@@ -1,0 +1,31 @@
+# PII Calibration Dataset
+
+The file [`jobs/pii_calib_set.json`](../jobs/pii_calib_set.json) contains a synthetic
+calibration set used for tuning PII detection heuristics.
+
+## Generation
+
+Entries were programmatically generated to cover three labels:
+
+* `key` – secrets with relatively low entropy
+* `email` – email-like tokens with higher entropy
+* `none` – near misses that should not be identified as PII
+
+Each record stores the text sample, its label, and a precalculated Shannon entropy.
+
+## Validation
+
+`jobs/pii_calibrate.py` recomputes entropy values and flags items whose entropy
+falls outside the expected range. To ensure the dataset composition remains
+stable, `tests/test_pii_calibrate.py` verifies the label distribution. The
+current split is:
+
+* 220 `key` samples (40%)
+* 193 `email` samples (35%)
+* 137 `none` samples (25%)
+
+Run the following to validate the dataset:
+
+```bash
+pytest tests/test_pii_calibrate.py
+```

--- a/tests/test_pii_calibrate.py
+++ b/tests/test_pii_calibrate.py
@@ -3,6 +3,8 @@ import importlib
 import io
 import json
 import string
+from collections import Counter
+from pathlib import Path
 
 import pytest
 
@@ -30,3 +32,11 @@ def test_entropy_thresholds_and_flags(monkeypatch):
     assert module.calculate_shannon_entropy(low_entropy_text) < module.thresholds["low"]
     assert module.data[0]["flag"] == "high"
     assert module.data[1]["flag"] == "low"
+
+
+def test_label_distribution():
+    dataset_path = Path(__file__).resolve().parent.parent / "jobs" / "pii_calib_set.json"
+    with dataset_path.open() as f:
+        data = json.load(f)
+    counts = Counter(item["label"] for item in data)
+    assert counts == {"key": 220, "email": 193, "none": 137}


### PR DESCRIPTION
## Summary
- add unit test ensuring PII calibration set keeps required label distribution
- document how the calibration dataset is generated and validated

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689eaab2fc508322aa3530dd00a45982