### PR TITLE
feat: add math agent

### DIFF
--- a/src/orchestrator/main.py
+++ b/src/orchestrator/main.py
@@ -7,6 +7,7 @@ from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 
 from .orchestrator import app as workflow_app
+from .math_agent import app as math_app
 
 
 app = FastAPI(title="NAESTRO Orchestrator")
@@ -64,4 +65,21 @@ def run(task: TaskRequest) -> RunResponse:
     except HTTPException:
         raise
     except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+class MathRequest(BaseModel):
+    """Payload for math queries."""
+
+    query: str
+
+
+@app.post("/math", response_model=RunResponse)
+def math(task: MathRequest) -> RunResponse:
+    """Execute the math agent and return the result."""
+
+    try:
+        result = math_app.invoke({"query": task.query})
+        return RunResponse(result=result)
+    except Exception as exc:  # pragma: no cover - defensive
         raise HTTPException(status_code=500, detail=str(exc))

--- a/src/orchestrator/math_agent.py
+++ b/src/orchestrator/math_agent.py
@@ -1,0 +1,64 @@
+import re
+from typing import Any, Dict
+
+import sympy as sp
+from langgraph.graph import StateGraph
+from scipy import integrate
+
+
+x = sp.symbols("x")
+
+def parse_math_query(query: str) -> Any:
+    """Parse a math query and execute it using SymPy/SciPy.
+
+    Supported commands:
+    - ``integrate <expr>`` for symbolic integration
+    - ``integrate <expr> from <a> to <b>`` for numeric integration
+    - ``differentiate <expr>`` for symbolic differentiation
+    - ``solve <expr>`` to solve expressions equal to zero
+    - ``simplify <expr>`` to simplify expressions
+    Otherwise the expression is evaluated symbolically.
+    """
+    query = query.strip()
+    # definite integral using SciPy
+    m = re.match(r"integrate\s+(.+)\s+from\s+(.+)\s+to\s+(.+)", query, re.I)
+    if m:
+        expr, lower, upper = m.groups()
+        func = sp.lambdify(x, sp.sympify(expr), "math")
+        a = float(sp.sympify(lower))
+        b = float(sp.sympify(upper))
+        val, _ = integrate.quad(func, a, b)
+        return val
+
+    m = re.match(r"integrate\s+(.+)", query, re.I)
+    if m:
+        expr = m.group(1)
+        return sp.integrate(sp.sympify(expr), x)
+
+    m = re.match(r"(differentiate|derive)\s+(.+)", query, re.I)
+    if m:
+        expr = m.group(2)
+        return sp.diff(sp.sympify(expr), x)
+
+    m = re.match(r"solve\s+(.+)", query, re.I)
+    if m:
+        expr = m.group(1)
+        return sp.solve(sp.sympify(expr), x)
+
+    m = re.match(r"simplify\s+(.+)", query, re.I)
+    if m:
+        expr = m.group(1)
+        return sp.simplify(sp.sympify(expr))
+
+    return sp.simplify(sp.sympify(query))
+
+def math_agent_fn(state: Dict[str, Any]) -> Dict[str, Any]:
+    query = state.get("query", "")
+    result = parse_math_query(query)
+    return {"result": result}
+
+
+_graph = StateGraph(dict)
+_graph.add_node("math", math_agent_fn)
+_graph.set_entry_point("math")
+app = _graph.compile()

--- a/src/orchestrator/requirements.txt
+++ b/src/orchestrator/requirements.txt
@@ -5,3 +5,6 @@ redis==5.0.8
 nltk==3.8.1
 flake8==7.0.0
 black==24.4.2
+sympy
+scipy
+langgraph

--- a/tests/test_math_agent.py
+++ b/tests/test_math_agent.py
@@ -1,0 +1,28 @@
+import pytest
+
+from src.orchestrator.math_agent import app as math_app, parse_math_query
+
+
+def test_parse_integrate_symbolic():
+    result = parse_math_query("integrate x**2")
+    assert str(result) == "x**3/3"
+
+
+def test_parse_differentiate():
+    result = parse_math_query("differentiate sin(x)")
+    assert str(result) == "cos(x)"
+
+
+def test_parse_solve():
+    result = parse_math_query("solve x**2 - 4")
+    assert set(map(str, result)) == {"-2", "2"}
+
+
+def test_parse_definite_integral():
+    result = parse_math_query("integrate sin(x) from 0 to pi")
+    assert result == pytest.approx(2.0, rel=1e-6)
+
+
+def test_math_app_invoke():
+    res = math_app.invoke({"query": "differentiate x**2"})
+    assert str(res["result"]) == "2*x"


### PR DESCRIPTION
## Summary
- implement math agent powered by SymPy/SciPy
- expose `/math` endpoint to run math queries through LangGraph
- cover typical math queries with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689eafb2797083228e6b1afea419b050