### PR TITLE
Add user manual and document Monaco UI and math demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,10 @@ secure sandboxing, and multi-model routing (NIM / vLLM / SLM).
 - **PII Calibration** — Shannon entropy thresholds with a 550-item dataset.
 - **Observability First** — OTEL traces, Prometheus metrics, Grafana dashboards (see `config/grafana/dashboards/naestro-dashboard.json`).
 - **CI/CD** — GitHub Actions with healthchecks and hooks for shadow/canary logic.
-- **Interactive Web UI** — React-based dashboard for inspecting workflows and monitoring runs.
+- **Interactive Web UI** — Monaco-powered React dashboard for inspecting workflows, editing prompts, and monitoring runs.
+- **SymPy & SciPy Demos** — example scripts for quadratic solving and sine integration.
+
+See [docs/USER_MANUAL.md](docs/USER_MANUAL.md) for a complete manual.
 
 ## 📦 Quick Start (Docker)
 ```bash

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -1,0 +1,50 @@
+# User Manual
+
+## Setup
+1. Clone the repository and install Python dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Create a `.env` file based on the example:
+   ```bash
+   cp .env.example .env
+   ```
+3. Launch core services with Docker:
+   ```bash
+   docker compose up -d --profile core
+   ```
+   Add the `inference` profile for GPU-backed models and `monitoring` for Prometheus/Grafana.
+
+## Services
+- **Gateway (8080)** – external API endpoint.
+- **Orchestrator (8081)** – workflow engine and routing logic.
+- **Inference Tier** – optional NIM, vLLM, and small model services.
+- **Monitoring Stack** – optional Prometheus + Grafana via the `monitoring` profile.
+
+## User Interface
+The React dashboard in `ui/` exposes workflow traces and a Monaco-based code editor for prompt and script editing.
+Start it separately:
+```bash
+cd ui
+npm install
+npm start
+```
+The UI runs on `http://localhost:3000` and communicates with the gateway.
+
+## Dataset Usage
+- **RAG Data** – create tables using `sql/schema.sql` and ingest your documents into the `documents` and `chunks` tables.
+- **PII Calibration Set** – `jobs/pii_calib_set.json` contains 550 labeled items. Run:
+  ```bash
+  python jobs/pii_calibrate.py
+  ```
+  to compute Shannon entropy flags for each item.
+
+## Math & Science Demos
+Example scripts illustrate SymPy and SciPy usage:
+```bash
+# Quadratic solver
+python -m src.examples.sympy_demo 1 0 -4
+
+# Integrate sin(x)
+python -m src.examples.scipy_demo
+```


### PR DESCRIPTION
## Summary
- Add comprehensive `docs/USER_MANUAL.md` covering setup, services, UI, dataset usage, and SymPy/SciPy demos
- Highlight Monaco-powered UI and math/science example scripts in README features
- Link README to the new manual

## Testing
- `pre-commit run --files README.md docs/USER_MANUAL.md` *(fails: .pre-commit-config.yaml is not a file)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689eb16c3db483229abc4ecbcb8eff9e