### PR TITLE
Document governor script and script requirements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,14 @@ jobs:
             echo "No root requirements.txt"
           fi
 
+      - name: Install scripts requirements (optional)
+        run: |
+          if [ -f scripts/requirements.txt ]; then
+            pip install -r scripts/requirements.txt
+          else
+            echo "No scripts requirements"
+          fi
+
       - name: Install gateway requirements (optional)
         run: |
           if [ -f src/gateway/requirements.txt ]; then

--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ curl http://localhost:8081/health
 
 **Local dev (no GPU / Codespaces):**
 ```bash
+pip install -r requirements.txt
+pip install -r scripts/requirements.txt  # utilities like governor.py
+
 # Start services directly (hot reload)
 uvicorn src.orchestrator.main:app --reload --port 8081 &
 uvicorn src.gateway.main:app --reload --port 8080 &

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -4,6 +4,7 @@
 1. Clone the repository and install Python dependencies:
    ```bash
    pip install -r requirements.txt
+   pip install -r scripts/requirements.txt  # utilities such as governor.py
    ```
 2. Create a `.env` file based on the example:
    ```bash
@@ -30,6 +31,14 @@
 - **Orchestrator (8081)** – workflow engine and routing logic.
 - **Inference Tier** – optional NIM, vLLM, and small model services.
 - **Monitoring Stack** – optional Prometheus + Grafana via the `monitoring` profile.
+
+## Governor Script
+`scripts/governor.py` adjusts EMA alpha based on Prometheus P95 latency.
+Install its requirements and run:
+```bash
+pip install -r scripts/requirements.txt
+python scripts/governor.py --prom-url http://localhost:9090
+```
 
 ## User Interface
 The React dashboard in `ui/` exposes workflow traces and a Monaco-based code editor for prompt and script editing.

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,2 @@
+requests
+prometheus-client


### PR DESCRIPTION
## Summary
- add `scripts/requirements.txt` for governor script dependencies
- document installing and running `scripts/governor.py`
- wire scripts requirements into CI and local dev instructions

## Testing
- `pre-commit run --files docs/USER_MANUAL.md README.md .github/workflows/ci.yml scripts/requirements.txt` *(fails: .pre-commit-config.yaml is not a file)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689ec662bc2083228ba1f508ef7df90f