### PR TITLE
Add release workflow and release documentation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,51 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push gateway image
+        uses: docker/build-push-action@v5
+        with:
+          context: src/gateway
+          push: true
+          tags: ghcr.io/${{ github.repository }}/gateway:${{ github.ref_name }}
+
+      - name: Build and push orchestrator image
+        uses: docker/build-push-action@v5
+        with:
+          context: src/orchestrator
+          push: true
+          tags: ghcr.io/${{ github.repository }}/orchestrator:${{ github.ref_name }}
+
+      - name: Generate changelog
+        id: changelog
+        run: |
+          echo "notes<<EOF" >> $GITHUB_OUTPUT
+          cat RELEASE_NOTES.md >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          body: ${{ steps.changelog.outputs.notes }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,10 @@
+# Releasing
+
+1. Update `RELEASE_NOTES.md` with details for the new version.
+2. Commit the changes to the repository.
+3. Create and push a version tag in the form `vX.Y.Z`.
+4. The release workflow will run automatically and:
+   - build and push Docker images for the gateway and orchestrator to `ghcr.io` tagged with the version,
+   - generate a GitHub Release using `RELEASE_NOTES.md` as the changelog.
+
+The workflow is defined in `.github/workflows/release.yml`.


### PR DESCRIPTION
## Summary
- add release workflow that builds and pushes gateway and orchestrator images on version tags
- generate changelog from RELEASE_NOTES.md and create GitHub release
- document the release process in RELEASING.md

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ecba057f08322b6ebeecfcb8d5570