### PR TITLE
chore: load Prometheus alert rules

### DIFF
--- a/config/prometheus.yml
+++ b/config/prometheus.yml
@@ -1,5 +1,7 @@
 global:
   scrape_interval: 15s
+rule_files:
+  - alerts.yml
 scrape_configs:
   - job_name: 'gateway'
     static_configs: [{ targets: ['gateway:8080'] }]


### PR DESCRIPTION
## Summary
- configure Prometheus to load `alerts.yml` rules

## Testing
- `pytest`
- `docker compose restart prometheus` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_689ed08f04ec8322ba21ae74b1ed639a