### PR TITLE
Add SLM service for inference profile

### DIFF
--- a/docker-compose.inference.yml
+++ b/docker-compose.inference.yml
@@ -2,3 +2,12 @@ version: '3.8'
 services:
   vllm:
     image: vllm/vllm:latest
+  slm:
+    image: ghcr.io/.../slm:${TAG}
+    profiles: ["inference"]
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - capabilities: ["gpu"]
+              device_ids: ["7"]


### PR DESCRIPTION
## Summary
- add SLM service to inference compose file with GPU reservation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ed1a677288322a65f2af1749818fb