### PR TITLE
Add pre-commit configuration for Python and UI code

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,32 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.12.1
+    hooks:
+      - id: black
+        exclude: ^ui/
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.2.1
+    hooks:
+      - id: ruff
+        args: [--fix]
+        exclude: ^ui/
+  - repo: https://github.com/pre-commit/mirrors-isort
+    rev: v5.9.3
+    hooks:
+      - id: isort
+        args: [--profile=black]
+        exclude: ^ui/
+  - repo: https://github.com/pre-commit/mirrors-eslint
+    rev: v9.32.0
+    hooks:
+      - id: eslint
+        args: [--fix]
+        files: ^ui/
+        types_or: [javascript, jsx, ts, tsx]
+        exclude: ^ui/node_modules/
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v3.1.0
+    hooks:
+      - id: prettier
+        files: ^ui/
+        exclude: ^ui/node_modules/

--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ See **ARCHITECTURE.md** and **docs/architecture.mmd** (Mermaid).
 See **SECURITY.md**. Sandbox is network-isolated with a strict seccomp profile.
 
 ## 🧹 Pre-commit
+Install the git hooks so formatting and lint checks run automatically:
+
 ```bash
 pip install pre-commit
 pre-commit install


### PR DESCRIPTION
## Summary
- enforce formatting and linting with black, ruff, isort for Python files
- add eslint and prettier checks for the `ui/` directory
- document pre-commit hook installation in README

## Testing
- `pre-commit run --files README.md .pre-commit-config.yaml`


------
https://chatgpt.com/codex/tasks/task_e_689ed71f49a483228b368951c6a2ed3d