### PR TITLE
chore: add node matrix and ui package config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,25 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [22, 24]
     steps:
       - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+          cache-dependency-path: ui/package-lock.json
+
+      - name: Install UI dependencies
+        working-directory: ui
+        run: npm ci
+
+      - name: Build UI
+        working-directory: ui
+        run: npm run build
 
       - uses: actions/setup-python@v5
         with:

--- a/ui/package.json
+++ b/ui/package.json
@@ -2,6 +2,14 @@
   "name": "naestro-ui",
   "version": "1.0.0",
   "private": true,
+  "engines": {
+    "node": ">=22 <25",
+    "npm": ">=10"
+  },
+  "packageManager": "npm@11",
+  "overrides": {
+    "sourcemap-codec": "npm:@jridgewell/sourcemap-codec@^1.5.0"
+  },
   "dependencies": {
     "@emotion/react": "^11.11.3",
     "@emotion/styled": "^11.11.0",


### PR DESCRIPTION
## Summary
- specify Node.js engine and npm requirements for the UI package, pin sourcemap-codec override, and note npm@11
- test UI build for Node 22 and 24 in CI using matrix strategy with caching

## Testing
- `npm ci`
- `npm run build`
- `pre-commit run --files .github/workflows/ci.yml ui/package.json`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ed93d61a48322a8c9c66dc0f9c03a