### PR TITLE
feat(ui): add Dockerfile for Nginx build

### DIFF
--- a/ui/.dockerignore
+++ b/ui/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,0 +1,22 @@
+# Stage 1: build
+FROM node:22-alpine AS build
+
+WORKDIR /app
+
+# Install dependencies
+COPY package*.json ./
+RUN npm ci
+
+# Copy source and build
+COPY . .
+RUN npm run build
+
+# Stage 2: production with Nginx
+FROM nginx:alpine
+
+COPY --from=build /app/dist /usr/share/nginx/html
+
+# Expose default port
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## Summary
- add multi-stage Dockerfile for the UI using Node 22 and Nginx
- ignore build artifacts and node_modules in the Docker context

## Testing
- `pre-commit run --files ui/Dockerfile ui/.dockerignore`
- `docker build ui` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*
- `act -W .github/workflows/release.yml -j build` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_689ee1ee4cec8322b1586bffe4073ea7