### PR TITLE
chore(ui): add overrides for build tooling

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -22,6 +22,10 @@
       "devDependencies": {
         "@vitejs/plugin-react-swc": "^3.5.0",
         "vite": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=22 <25",
+        "npm": ">=10"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -8,7 +8,10 @@
   },
   "packageManager": "npm@11",
   "overrides": {
-    "sourcemap-codec": "npm:@jridgewell/sourcemap-codec@^1.5.0"
+    "sourcemap-codec": "npm:@jridgewell/sourcemap-codec@^1.5.0",
+    "rimraf": "^5",
+    "glob": "^10",
+    "svgo": "^3"
   },
   "dependencies": {
     "@emotion/react": "^11.11.3",


### PR DESCRIPTION
## Summary
- add rimraf, glob, and svgo to overrides
- refresh npm lockfile

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.js file)*

------
https://chatgpt.com/codex/tasks/task_e_689ee3febea483228f4d07df92c7349c