### PR TITLE
chore: streamline ui package.json

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -6,13 +6,6 @@
     "node": ">=22.12 <25",
     "npm": ">=10"
   },
-  "packageManager": "npm@11",
-  "overrides": {
-    "sourcemap-codec": "npm:@jridgewell/sourcemap-codec@^1.5.0",
-    "rimraf": "^5",
-    "glob": "^10",
-    "svgo": "^3"
-  },
   "dependencies": {
     "@emotion/react": "^11.11.3",
     "@emotion/styled": "^11.11.0",
@@ -32,8 +25,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview",
-    "lint": "eslint ."
+    "preview": "vite preview"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
## Summary
- remove unused overrides and packageManager
- limit scripts to dev, build, and preview

## Testing
- `pre-commit run --files ui/package.json`
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ef5374534832283c960fb887a0246