### PR TITLE
ci: use nvmrc node version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,15 +9,12 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node: [22, 24]
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node }}
+          node-version-file: ui/.nvmrc
           cache: npm
           cache-dependency-path: ui/package-lock.json
 


### PR DESCRIPTION
## Summary
- use node version from `ui/.nvmrc`

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689efd5a817c83229c52aa12acc943fe