### PR TITLE
docs: document lock-based installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,13 +55,16 @@ curl http://localhost:8081/health
 
 **Local dev (no GPU / Codespaces):**
 ```bash
-pip install -r requirements.txt
+pip install -r requirements.lock
 pip install -r scripts/requirements.txt  # utilities like governor.py
 
 # Start services directly (hot reload)
 uvicorn src.orchestrator.main:app --reload --port 8081 &
 uvicorn src.gateway.main:app --reload --port 8080 &
 ```
+
+Dependencies are pinned for reproducibility. After editing any `requirements.txt`,
+regenerate the corresponding `*.lock` file with `pip-compile`.
 
 ## DGX Spark Setup
 - Use DGX OS (Ubuntu-based).

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -3,9 +3,11 @@
 ## Setup
 1. Clone the repository and install Python dependencies:
    ```bash
-   pip install -r requirements.txt
+   pip install -r requirements.lock
    pip install -r scripts/requirements.txt  # utilities such as governor.py
    ```
+   Dependencies are pinned via `*.lock` files. If you change any
+   `requirements.txt`, regenerate the lock with `pip-compile`.
 2. Create a `.env` file based on the example:
    ```bash
    cp .env.example .env

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -2,10 +2,10 @@
 
 This repository includes small demonstrations of third-party libraries.
 
-Install dependencies with:
+Install dependencies with pinned versions:
 
 ```bash
-pip install -r requirements.txt
+pip install -r requirements.lock
 ```
 
 


### PR DESCRIPTION
## Summary
- document lock-file installs in README, manual, and examples
- explain regenerating `*.lock` files with `pip-compile`

## Testing
- `pre-commit run --files README.md docs/USER_MANUAL.md docs/examples.md`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f0643bab8832297471c588766c1d7