### PR TITLE
docs: add runbook guides

### DIFF
--- a/docs/DEPLOY_SINGLE_NODE.md
+++ b/docs/DEPLOY_SINGLE_NODE.md
@@ -1,0 +1,25 @@
+# Deploy Single Node
+
+## TL;DR
+| Step | Command | Notes |
+|------|---------|-------|
+| Build images | `docker compose build` | Prepare containers |
+| Start services | `docker compose up -d` | Launch orchestrator and models |
+| Validate | `curl http://localhost:8000/health` | Should return `ok` |
+
+## Overview
+Run Naestro and supporting services on a single machine using Docker Compose.
+
+## Steps
+1. Ensure Docker and Docker Compose are installed.
+2. Build images and start services using the compose file.
+3. Monitor logs with `docker compose logs -f`.
+
+## Validation
+Send a test prompt through the API or UI and confirm a response.
+
+## Troubleshooting
+| Issue | Resolution |
+|-------|-----------|
+| Containers failing to start | Check Docker logs and available resources |
+| Ports conflict | Adjust exposed ports in `docker-compose.yml` |

--- a/docs/GRAPHITI.md
+++ b/docs/GRAPHITI.md
@@ -1,0 +1,28 @@
+# Graphiti Runbook
+
+## TL;DR
+| Step | Command | Notes |
+|------|---------|-------|
+| Deploy Graphiti service | `docker compose up graphiti` | Runs local graph engine |
+| Configure Naestro | set `GRAPHITI_URL` and `GRAPHITI_API_KEY` | Include optional semaphore limit |
+| Verify connectivity | `curl $GRAPHITI_URL/health` | Should return `ok` |
+
+## Overview
+Graphiti provides bi-temporal, persistent memory for Naestro orchestration.
+
+## Steps
+### Deploy Graphiti
+Launch the Graphiti container or binary along with a compatible graph database backend.
+
+### Configure Naestro
+Set the environment variables and enable the Graphiti client in the orchestrator configuration.
+
+### Validate
+Start Naestro and ensure episodes are recorded and retrieved through the Graphiti endpoints.
+
+## Troubleshooting
+| Symptom | Fix |
+|---------|-----|
+| Connection refused | Check that Graphiti is listening on the expected port |
+| Missing episodes | Confirm the client is calling `recordEpisode` and `context.assemble` |
+| Slow queries | Tune `GRAPHITI_SEMAPHORE_LIMIT` and review backend performance |

--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -1,0 +1,28 @@
+# Integrations Runbook
+
+## TL;DR
+| Integration | Purpose | Configuration |
+|-------------|---------|---------------|
+| Graphiti | Real-time knowledge graph memory | Set `GRAPHITI_URL` and `GRAPHITI_API_KEY` |
+| VS Code Extension | Developer tooling for local agents | Install Naestro VS Code extension |
+| UI API | Contract between UI and core | See `UI_API_CONTRACT.md` |
+
+## Summary
+This runbook outlines how Naestro connects to optional components and developer tools.
+
+## Steps
+1. Set the necessary environment variables for each integration.
+2. Restart the orchestrator to pick up configuration changes.
+3. Validate each integration using health checks or sample commands.
+
+## Validation
+- Graphiti: `curl $GRAPHITI_URL/health`
+- VS Code: verify extension activates in the editor.
+- UI API: check API responses match contract.
+
+## Troubleshooting
+| Issue | Resolution |
+|-------|-----------|
+| Missing API key | Ensure secret is set in environment or `.env` file |
+| Extension not loading | Restart VS Code and check logs |
+| API mismatch | Compare request/response with contract table |

--- a/docs/NO_REPLIT_DEPLOY.md
+++ b/docs/NO_REPLIT_DEPLOY.md
@@ -1,0 +1,26 @@
+# No Replit Deploy
+
+## TL;DR
+| Step | Command | Notes |
+|------|---------|-------|
+| Clone repository | `git clone https://github.com/naestro/naestro.git` | Perform on a local machine or server |
+| Install dependencies | `pip install -r requirements.txt` | Use Python 3.10+ |
+| Run orchestrator | `python -m src.main` | Starts API on port 8000 |
+
+## Overview
+Instructions for deploying Naestro without relying on Replit.
+
+## Steps
+1. Ensure Docker or Python environment is available.
+2. Clone the repository and install dependencies.
+3. Configure environment variables as needed.
+4. Start the orchestrator service.
+
+## Validation
+Access `http://localhost:8000/health` to confirm the service is running.
+
+## Troubleshooting
+| Issue | Resolution |
+|-------|-----------|
+| Missing Python headers | Install `python3-dev` on the host |
+| Port already in use | Adjust `PORT` environment variable |

--- a/docs/UI_API_CONTRACT.md
+++ b/docs/UI_API_CONTRACT.md
@@ -1,0 +1,28 @@
+# UI API Contract
+
+## TL;DR
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/api/tasks` | GET | List running tasks |
+| `/api/tasks` | POST | Create a new task |
+| `/api/events` | SSE | Stream agent events for a task |
+
+## Overview
+This document defines the contract between Naestro's UI and core API service.
+
+## Payloads
+| Field | Type | Notes |
+|-------|------|-------|
+| `id` | string | Unique task identifier |
+| `prompt` | string | User request submitted via UI |
+| `status` | enum | `pending`, `running`, or `done` |
+
+## Error Codes
+| Code | Meaning |
+|------|--------|
+| 400 | Validation failure |
+| 404 | Task not found |
+| 500 | Internal error |
+
+## Troubleshooting
+Ensure UI and API versions are compatible and that CORS settings allow browser requests.

--- a/docs/VS_CODE_EXTENSION.md
+++ b/docs/VS_CODE_EXTENSION.md
@@ -1,0 +1,25 @@
+# VS Code Extension
+
+## TL;DR
+| Step | Command | Notes |
+|------|---------|-------|
+| Install extension | `code --install-extension naestro.vsix` | Load local VSIX package |
+| Connect to API | Set `NAESTRO_API_URL` in settings | Points extension to running orchestrator |
+| Run task | Use command palette "Naestro: Run Task" | Sends prompt to API |
+
+## Overview
+The VS Code extension provides an editor workflow for submitting tasks to Naestro and viewing responses.
+
+## Steps
+1. Install the extension from the packaged VSIX file.
+2. Configure settings for API URL and authentication token if required.
+3. Use command palette or sidebar to create and monitor tasks.
+
+## Validation
+Run a sample prompt and ensure responses appear in the output panel.
+
+## Troubleshooting
+| Issue | Resolution |
+|-------|-----------|
+| Extension not found | Check VSIX path or marketplace availability |
+| Cannot reach API | Confirm `NAESTRO_API_URL` is set and service is running |


### PR DESCRIPTION
## Summary
- add runbooks for integrations, Graphiti, UI API contract, and deployment scenarios
- document VS Code extension usage and non-Replit deployment steps

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b691413f88832a8486f2294fe74f51