### PR TITLE
docs: add studio readme

### DIFF
--- a/studio/README.md
+++ b/studio/README.md
@@ -1,0 +1,11 @@
+# Studio
+
+This directory contains the user interface layer for Naestro.
+
+## Stack
+
+- **React** with **Vite** for application structure and build tooling.
+- **Tailwind CSS** paired with **shadcn/ui** components for styling.
+- Real-time communication via a WebSocket client with a Server-Sent Events (SSE) fallback.
+- Includes KPI cards, live run monitoring, model management, and settings views.
+


### PR DESCRIPTION
## Summary
- add `studio/README.md` outlining stack (React, Vite, Tailwind, shadcn/ui) and features like live runs and models

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b69168cd04832abcddfff50affc19a