### PR TITLE
docs: add multi-node deployment guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Naestro is an AI Orchestrator for multi-model collaboration.
 - **Graph Memory (Graphiti) guide** → [docs/GRAPHITI.md](docs/GRAPHITI.md)
 - **Studio ↔ Core API contract (REST/WS/SSE, auth)** → [docs/UI_API_CONTRACT.md](docs/UI_API_CONTRACT.md)
 - **Single-node DGX Spark deployment** → [docs/DEPLOY_SINGLE_NODE.md](docs/DEPLOY_SINGLE_NODE.md)
+- **Multi-node DGX Spark deployment** → [docs/DEPLOY_MULTI_NODE.md](docs/DEPLOY_MULTI_NODE.md)
 - **VS Code add-on (Qoder-style) spec** → [docs/VS_CODE_EXTENSION.md](docs/VS_CODE_EXTENSION.md)
 - **No-Replit deployment (Caddy + Cloudflare Tunnel)** → [docs/NO_REPLIT_DEPLOY.md](docs/NO_REPLIT_DEPLOY.md)
 

--- a/config/.env.example
+++ b/config/.env.example
@@ -1,8 +1,10 @@
-# === Naestro single-node DGX Spark (desktop) ===
-NAESTRO_DEPLOYMENT=single_node
+# === Naestro DGX Spark (single or multi-node) ===
+NAESTRO_DEPLOYMENT=single_node  # set to "multi_node" for multi-host
 GPU_POLICY=tensorrt_llm
 LOCAL_MODELS=llama-3.1-70b-fp8,deepseek-v3.2-32b,qwen-3-32b-awq
-CONCURRENCY_MAX=8
+# Comma-separated list of DGX hostnames providing inference
+MODEL_HOSTS=dgx-a,dgx-b
+CONCURRENCY_MAX=16
 WS_HEARTBEAT_MS=20000
 
 # Providers & endpoints

--- a/config/providers.yaml
+++ b/config/providers.yaml
@@ -1,26 +1,50 @@
-# Naestro providers: single-node DGX Spark (local-first) + cloud spillover
+# Naestro providers: multi-node DGX Spark (local-first) + cloud spillover
 
 inference:
   local:
-    - id: llama70b_judge
+    # DGX A
+    - id: llama70b_judge_dgx_a
       runtime: tensorrt_llm
       model: llama-3.1-70b-instruct-fp8
-      endpoint: http://127.0.0.1:8001
+      endpoint: http://dgx-a:8001
       max_batch: 4
       kv_cache: fp8
       roles: [judge, proposer]
 
-    - id: deepseek32b
+    - id: deepseek32b_dgx_a
       runtime: vllm
       model: deepseek-v3.2-32b-instruct
-      endpoint: http://127.0.0.1:8002
+      endpoint: http://dgx-a:8002
       max_batch: 8
       roles: [proposer, synthesizer]
 
-    - id: qwen32b_awq
+    - id: qwen32b_awq_dgx_a
       runtime: vllm
       model: qwen-3-32b-instruct-awq
-      endpoint: http://127.0.0.1:8003
+      endpoint: http://dgx-a:8003
+      max_batch: 12
+      roles: [critic, code]
+
+    # DGX B
+    - id: llama70b_judge_dgx_b
+      runtime: tensorrt_llm
+      model: llama-3.1-70b-instruct-fp8
+      endpoint: http://dgx-b:8001
+      max_batch: 4
+      kv_cache: fp8
+      roles: [judge, proposer]
+
+    - id: deepseek32b_dgx_b
+      runtime: vllm
+      model: deepseek-v3.2-32b-instruct
+      endpoint: http://dgx-b:8002
+      max_batch: 8
+      roles: [proposer, synthesizer]
+
+    - id: qwen32b_awq_dgx_b
+      runtime: vllm
+      model: qwen-3-32b-instruct-awq
+      endpoint: http://dgx-b:8003
       max_batch: 12
       roles: [critic, code]
 
@@ -46,17 +70,17 @@ inference:
 routing:
   policy: local_first_with_cloud_spill
   defaults:
-    judge: llama70b_judge
-    proposer: deepseek32b
-    critic: qwen32b_awq
-    synthesizer: deepseek32b
+    judge: llama70b_judge_dgx_a
+    proposer: deepseek32b_dgx_a
+    critic: qwen32b_awq_dgx_a
+    synthesizer: deepseek32b_dgx_a
   fallbacks:
-    judge: [anthropic_claude37, openai_gpt4x]
-    proposer: [openai_gpt4x]
-    critic: [openai_gpt4x]
-    synthesizer: [google_gemini25]
+    judge: [llama70b_judge_dgx_b, anthropic_claude37, openai_gpt4x]
+    proposer: [deepseek32b_dgx_b, openai_gpt4x]
+    critic: [qwen32b_awq_dgx_b, openai_gpt4x]
+    synthesizer: [deepseek32b_dgx_b, google_gemini25]
   limits:
-    max_concurrency: 8
+    max_concurrency: 16
     max_tokens_per_run: 120000
     long_context_threshold: 200000
 

--- a/docs/DEPLOY_MULTI_NODE.md
+++ b/docs/DEPLOY_MULTI_NODE.md
@@ -1,0 +1,52 @@
+# Deploy Multi Node
+
+[\u2190 Back to README](../README.md)
+
+## Overview
+Run Naestro across multiple DGX Spark desktops. This setup spreads inference services over several hosts while a single gateway and orchestrator coordinate requests.
+
+## Networking
+- Ensure each DGX is reachable over the network (e.g. `dgx-a`, `dgx-b`).
+- Open the inference ports (8001\-8003 by default) on each host.
+- Optionally place nodes on an isolated subnet for lower latency.
+
+## Orchestration
+1. On **each** DGX host, start the Naestro services:
+   ```bash
+   docker compose up -d --profile core inference
+   ```
+2. Copy `config/providers.yaml` and point each provider's `endpoint` to the correct host (see example below).
+3. Set `MODEL_HOSTS` in `.env` to a comma-separated list of DGX hostnames.
+
+## Load Balancing
+- Duplicate provider entries for each DGX with unique `id` and `endpoint` values.
+- Increase `routing.limits.max_concurrency` to reflect the number of hosts.
+- Naestro will route requests across all listed providers in a round-robin fashion.
+
+## Example
+`config/providers.yaml`
+```yaml
+inference:
+  local:
+    - id: llama70b_judge_dgx_a
+      endpoint: http://dgx-a:8001
+    - id: llama70b_judge_dgx_b
+      endpoint: http://dgx-b:8001
+routing:
+  limits:
+    max_concurrency: 16
+```
+
+## Validation
+Send a test prompt to the gateway and verify that responses are returned from each host.
+
+## Troubleshooting
+| Issue | Resolution |
+|-------|-----------|
+| Nodes unreachable | Check firewall rules and hostnames |
+| Uneven load | Confirm `max_concurrency` and provider IDs are unique |
+| Slow responses | Verify network bandwidth between hosts |
+
+---
+
+See also: [INTEGRATIONS](INTEGRATIONS.md) · [GRAPHITI](GRAPHITI.md) · [UI_API_CONTRACT](UI_API_CONTRACT.md) · [DEPLOY_SINGLE_NODE](DEPLOY_SINGLE_NODE.md)


### PR DESCRIPTION
## Summary
- document multi-node Naestro deployment for DGX Spark clusters
- link multi-node guide from README documentation section
- add multi-host examples in providers and env configuration

## Testing
- `pre-commit run --files docs/DEPLOY_MULTI_NODE.md README.md config/providers.yaml config/.env.example`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b6b029b684832a975da1f2e2f3379a