### PR TITLE
feat: add Apple OpenELM (vLLM) snippet to single-node docs and provider entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ Naestro is an AI Orchestrator for multi-model collaboration.
 - **VS Code add-on (Qoder-style) spec** → [docs/VS_CODE_EXTENSION.md](docs/VS_CODE_EXTENSION.md)
 - **No-Replit deployment (Caddy + Cloudflare Tunnel)** → [docs/NO_REPLIT_DEPLOY.md](docs/NO_REPLIT_DEPLOY.md)
 
+### Scale-out from single node
+Naestro runs great on a single DGX Spark desktop. When you’re ready to expand across multiple desktops (“cells”), see **[DEPLOY_MULTI_NODE.md](docs/DEPLOY_MULTI_NODE.md)**. Cells register with the router; the scheduler places steps by VRAM headroom, temperature, and queue pressure—local-first with cloud spillover only when needed.
+
 ### Naestro Studio (local UI)
 First-party dashboard (React + Vite + Tailwind + shadcn/ui) served by Naestro Core on the DGX.  \
 Real-time Live Runs, model metrics, GPU health, KV cache hit-rate, cloud spillover %, and incidents.  \

--- a/config/.env.example
+++ b/config/.env.example
@@ -25,3 +25,6 @@ NAESTRO_JWT_SECRET=replace_me
 # Metrics/observability
 METRICS_EXPORT=otel
 
+# Optional sidecar endpoints
+APPLE_ROUTER_URL=http://127.0.0.1:8602/v1
+

--- a/config/providers.yaml
+++ b/config/providers.yaml
@@ -48,6 +48,15 @@ inference:
       max_batch: 12
       roles: [critic, code]
 
+    # Apple OpenELM router provider (local OpenAI-compatible endpoint)
+    - id: apple_openelm_router
+      cell: local-01
+      runtime: openai
+      model: apple/OpenELM-3B-Instruct
+      endpoint: http://127.0.0.1:8602/v1
+      roles: [router, proposer, critic]
+      max_output_tokens: 4096
+
   cloud:
     - id: openai_gpt4x
       provider: openai

--- a/docs/DEPLOY_SINGLE_NODE.md
+++ b/docs/DEPLOY_SINGLE_NODE.md
@@ -29,3 +29,22 @@ Send a test prompt through the API or UI and confirm a response.
 ---
 
 See also: [INTEGRATIONS](INTEGRATIONS.md) · [GRAPHITI](GRAPHITI.md) · [UI_API_CONTRACT](UI_API_CONTRACT.md) · [DEPLOY_SINGLE_NODE](DEPLOY_SINGLE_NODE.md)
+
+### Optional: Apple OpenELM Router (vLLM)
+
+You can run a lightweight local router/assistant using **Apple/OpenELM-3B-Instruct** via **vLLM** with an OpenAI-compatible API:
+
+```bash
+pip install vllm
+
+python -m vllm.entrypoints.openai.api_server \
+  --model apple/OpenELM-3B-Instruct \
+  --host 0.0.0.0 \
+  --port 8602 \
+  --gpu-memory-utilization 0.85
+```
+
+This exposes an OpenAI-style endpoint at `http://localhost:8602/v1`.
+Adjust `--gpu-memory-utilization` or add flags like `--max-model-len` depending on your GPU VRAM.
+
+Update `config/providers.yaml` to add the provider (see “Apple OpenELM router provider” example).


### PR DESCRIPTION
## Summary
- document optional Apple OpenELM router for single-node deployments
- add apple_openelm_router provider entry and env example variable
- note scale-out path from single node in README

## Testing
- `pytest`
- `pre-commit run --files README.md config/.env.example config/providers.yaml docs/DEPLOY_SINGLE_NODE.md`

------
https://chatgpt.com/codex/tasks/task_b_68b6b3fcfac8832ab01a532633757aa8