### PR TITLE
Refactor PII calibration into main function

### DIFF
--- a/jobs/pii_calibrate.py
+++ b/jobs/pii_calibrate.py
@@ -1,27 +1,36 @@
-from collections import Counter
 import json
 import math
+from collections import Counter
 from pathlib import Path
 
 
 def calculate_shannon_entropy(text):
     counts = Counter(text)
     length = len(text)
-    entropy = -sum((count / length) * math.log2(count / length) for count in counts.values())
+    entropy = -sum(
+        (count / length) * math.log2(count / length) for count in counts.values()
+    )
     return entropy
 
 
-with open(Path(__file__).with_name("pii_calib_set.json")) as f:
-    data = json.load(f)
-
 thresholds = {"high": 4.5, "low": 2.5}  # From spec
+data = None
 
-for item in data:
-    entropy = calculate_shannon_entropy(item["text"])
-    if entropy > thresholds["high"] and item["label"] == "key":
-        item["flag"] = "high"
-    if entropy < thresholds["low"] and item["label"] == "email":
-        item["flag"] = "low"
 
-print("Thresholds:", thresholds)
+def main():
+    global data
+    with open(Path(__file__).with_name("pii_calib_set.json")) as f:
+        data = json.load(f)
 
+    for item in data:
+        entropy = calculate_shannon_entropy(item["text"])
+        if entropy > thresholds["high"] and item["label"] == "key":
+            item["flag"] = "high"
+        if entropy < thresholds["low"] and item["label"] == "email":
+            item["flag"] = "low"
+
+    print("Thresholds:", thresholds)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_pii_calibrate.py
+++ b/tests/test_pii_calibrate.py
@@ -6,8 +6,6 @@ import string
 from collections import Counter
 from pathlib import Path
 
-import pytest
-
 
 def test_entropy_thresholds_and_flags(monkeypatch):
     # Prepare sample dataset with high and low entropy texts
@@ -27,15 +25,20 @@ def test_entropy_thresholds_and_flags(monkeypatch):
 
     monkeypatch.setattr(builtins, "open", fake_open)
     module = importlib.reload(importlib.import_module("jobs.pii_calibrate"))
+    module.main()
 
-    assert module.calculate_shannon_entropy(high_entropy_text) > module.thresholds["high"]
+    assert (
+        module.calculate_shannon_entropy(high_entropy_text) > module.thresholds["high"]
+    )
     assert module.calculate_shannon_entropy(low_entropy_text) < module.thresholds["low"]
     assert module.data[0]["flag"] == "high"
     assert module.data[1]["flag"] == "low"
 
 
 def test_label_distribution():
-    dataset_path = Path(__file__).resolve().parent.parent / "jobs" / "pii_calib_set.json"
+    dataset_path = (
+        Path(__file__).resolve().parent.parent / "jobs" / "pii_calib_set.json"
+    )
     with dataset_path.open() as f:
         data = json.load(f)
     counts = Counter(item["label"] for item in data)


### PR DESCRIPTION
## Summary
- wrap dataset loading and flagging in a `main()` entry point
- expose `calculate_shannon_entropy` helper and add `__main__` guard
- update tests to invoke `main`

## Testing
- `pre-commit run --files jobs/pii_calibrate.py`
- `pre-commit run --files tests/test_pii_calibrate.py`
- `pytest tests/test_pii_calibrate.py`


------
https://chatgpt.com/codex/tasks/task_b_68b6c2f5bb04832ab5062c08202105ad