### PR TITLE
Refactor RAG utilities for lazy model and typed results

### DIFF
--- a/src/rag.py
+++ b/src/rag.py
@@ -1,100 +1,162 @@
-from sentence_transformers import SentenceTransformer
-from psycopg2.pool import SimpleConnectionPool
+from __future__ import annotations
+
 import logging
 import os
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Iterable
 
-
-model = SentenceTransformer("all-MiniLM-L12-v2")
+from psycopg2.pool import SimpleConnectionPool
+from sentence_transformers import SentenceTransformer
 
 logger = logging.getLogger(__name__)
 
-pool: SimpleConnectionPool | None = None
+
+# --- Model loading -------------------------------------------------------
+model: SentenceTransformer | None = None
+
+
+def init_model() -> SentenceTransformer:
+    """Lazily initialize and return the text embedding model."""
+    global model
+    if model is None:
+        model = SentenceTransformer("all-MiniLM-L12-v2")
+    return model
+
+
+# --- Connection pool -----------------------------------------------------
+
+
+class ConnectionPool:
+    """Wrapper around :class:`SimpleConnectionPool` with context manager access."""
+
+    def __init__(self, dsn: str, minconn: int, maxconn: int) -> None:
+        self._pool = SimpleConnectionPool(minconn, maxconn, dsn)
+
+    @contextmanager
+    def connection(self):
+        conn = self._pool.getconn()
+        try:
+            yield conn
+        finally:
+            self._pool.putconn(conn)
+
+    def close(self) -> None:
+        self._pool.closeall()
+
+
+pool: ConnectionPool | None = None
 
 
 def init_connection_pool(
     dsn: str | None = None, minconn: int = 1, maxconn: int = 10
-) -> SimpleConnectionPool:
+) -> ConnectionPool:
     """Initialize a connection pool for PostgreSQL."""
     global pool
     if pool is None:
         dsn = dsn or os.getenv("DATABASE_URL")
         if not dsn:
             raise ValueError("DSN required for connection pool")
-        pool = SimpleConnectionPool(minconn, maxconn, dsn)
+        pool = ConnectionPool(dsn, minconn, maxconn)
     return pool
 
 
-def _get_conn():
+def close_pool() -> None:
+    """Close the global connection pool if it exists."""
+    global pool
+    if pool is not None:
+        pool.close()
+        pool = None
+
+
+# --- Embedding helpers ---------------------------------------------------
+
+
+def embed_text(text: str) -> Iterable[float]:
+    """Return an embedding vector for the provided text."""
+    return init_model().encode(text)
+
+
+# --- Dataclasses ---------------------------------------------------------
+
+
+@dataclass
+class InsertEmbeddingResult:
+    id: int
+
+
+@dataclass
+class HybridSearchResult:
+    rows: list
+
+
+@dataclass
+class UpdateFeedbackResult:
+    updated: int
+
+
+# --- Database operations -------------------------------------------------
+
+
+def insert_embedding(text: str, embedding: Iterable[float]) -> InsertEmbeddingResult:
+    """Insert an embedding into the database."""
     if pool is None:
         raise RuntimeError("Connection pool not initialized")
-    return pool.getconn()
-
-
-def _put_conn(conn):
-    if pool:
-        pool.putconn(conn)
-
-
-def embed_text(text: str):
-    return model.encode(text)
-
-
-def insert_embedding(text: str, embedding):
-    conn = _get_conn()
-    try:
-        with conn.cursor() as cur:
-            cur.execute(
-                "INSERT INTO embeddings (chunk_tsv, embedding) VALUES (to_tsvector('english', %s), %s) RETURNING id",
-                (text, embedding),
-            )
+    with pool.connection() as conn:
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "INSERT INTO embeddings (chunk_tsv, embedding) VALUES (to_tsvector('english', %s), %s) RETURNING id",
+                    (text, embedding),
+                )
+                inserted_id = cur.fetchone()[0]
             conn.commit()
-            inserted_id = cur.fetchone()[0]
-        return {"success": True, "id": inserted_id}
-    except Exception as exc:
-        conn.rollback()
-        logger.exception("Failed to insert embedding")
-        return {"success": False, "error": str(exc)}
-    finally:
-        _put_conn(conn)
+            return InsertEmbeddingResult(id=inserted_id)
+        except Exception:  # pragma: no cover - logging
+            conn.rollback()
+            logger.exception("Failed to insert embedding")
+            raise
 
 
-def hybrid_search(query: str):
-    conn = _get_conn()
+def hybrid_search(query: str) -> HybridSearchResult:
+    """Perform hybrid full-text and vector similarity search."""
+    if pool is None:
+        raise RuntimeError("Connection pool not initialized")
     emb = embed_text(query)
-    try:
-        with conn.cursor() as cur:
-            cur.execute(
-                """
-                SELECT * FROM embeddings
-                WHERE chunk_tsv @@ plainto_tsquery(%s)
-                ORDER BY embedding <-> %s LIMIT 50;
-                """,
-                (query, emb),
-            )
-            rows = cur.fetchall()
-        return {"success": True, "rows": rows}
-    except Exception as exc:
-        conn.rollback()
-        logger.exception("Failed to perform hybrid search")
-        return {"success": False, "error": str(exc)}
-    finally:
-        _put_conn(conn)
+    with pool.connection() as conn:
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT * FROM embeddings
+                    WHERE chunk_tsv @@ plainto_tsquery(%s)
+                    ORDER BY embedding <-> %s LIMIT 50;
+                    """,
+                    (query, emb),
+                )
+                rows = cur.fetchall()
+            return HybridSearchResult(rows=rows)
+        except Exception:  # pragma: no cover - logging
+            conn.rollback()
+            logger.exception("Failed to perform hybrid search")
+            raise
 
 
-def update_feedback(id: int, boost: float = 0.1):
-    conn = _get_conn()
-    try:
-        with conn.cursor() as cur:
-            cur.execute(
-                "UPDATE embeddings SET feedback_boost = feedback_boost + %s WHERE id = %s",
-                (boost, id),
-            )
+def update_feedback(id: int, boost: float = 0.1) -> UpdateFeedbackResult:
+    """Adjust feedback boost for an embedding row."""
+    if pool is None:
+        raise RuntimeError("Connection pool not initialized")
+    with pool.connection() as conn:
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "UPDATE embeddings SET feedback_boost = feedback_boost + %s WHERE id = %s",
+                    (boost, id),
+                )
+                updated = cur.rowcount
             conn.commit()
-            updated = cur.rowcount
-        return {"success": True, "updated": updated}
-    except Exception as exc:
-        conn.rollback()
-        logger.exception("Failed to update feedback")
-        return {"success": False, "error": str(exc)}
-    finally:
-        _put_conn(conn)
+            return UpdateFeedbackResult(updated=updated)
+        except Exception:  # pragma: no cover - logging
+            conn.rollback()
+            logger.exception("Failed to update feedback")
+            raise


### PR DESCRIPTION
## Summary
- Lazily initialize embedding model via `init_model`
- Wrap PostgreSQL connection pool in `ConnectionPool` with closing helper
- Use dataclasses for database operations instead of dicts and add type hints

## Testing
- `pre-commit run --files src/rag.py`
- `pytest tests/test_rag.py`


------
https://chatgpt.com/codex/tasks/task_b_68b6c3db7cec832a84aed9eb67bc539d