### PR TITLE
feat(ui): add prop types to CodeEditor

### DIFF
--- a/ui/src/components/CodeEditor.jsx
+++ b/ui/src/components/CodeEditor.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Editor, DiffEditor } from '@monaco-editor/react';
 
-const CodeEditor = ({ original = '', modified, language = 'javascript', height = '400px' }) => {
-  if (modified !== undefined) {
+const CodeEditor = ({ original, modified, language = 'javascript', height }) => {
+  if (modified) {
     return (
       <DiffEditor
         original={original}
@@ -22,6 +23,18 @@ const CodeEditor = ({ original = '', modified, language = 'javascript', height =
       options={{ automaticLayout: true }}
     />
   );
+};
+
+CodeEditor.propTypes = {
+  language: PropTypes.string.isRequired,
+  original: PropTypes.string,
+  modified: PropTypes.string,
+  height: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
+};
+CodeEditor.defaultProps = {
+  original: '',
+  modified: '',
+  height: 400
 };
 
 export default CodeEditor;

--- a/ui/src/main.jsx
+++ b/ui/src/main.jsx
@@ -1,10 +1,11 @@
-import React from 'react'
-import ReactDOM from 'react-dom/client'
-import App from './App'
+/* globals document */
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <App />
   </React.StrictMode>
-)
+);
 


### PR DESCRIPTION
## Summary
- add PropTypes and default props for CodeEditor
- declare `document` global in main.jsx for eslint

## Testing
- `npm run lint`
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_b_68b6ea1f9f7c832a81d749005902b6f4