### PR TITLE
fix: adjust CodeEditor PropTypes

### DIFF
--- a/ui/eslint.config.js
+++ b/ui/eslint.config.js
@@ -19,6 +19,9 @@ export default [
       import: importPlugin,
       "@typescript-eslint": tsPlugin,
     },
+    settings: {
+      react: { version: "detect" }
+    },
     rules: {
       ...reactPlugin.configs.recommended.rules,
       ...reactHooks.configs.recommended.rules,

--- a/ui/src/components/CodeEditor.jsx
+++ b/ui/src/components/CodeEditor.jsx
@@ -26,7 +26,7 @@ const CodeEditor = ({ original, modified, language = 'javascript', height }) => 
 };
 
 CodeEditor.propTypes = {
-  language: PropTypes.string.isRequired,
+  language: PropTypes.string,
   original: PropTypes.string,
   modified: PropTypes.string,
   height: PropTypes.oneOfType([PropTypes.number, PropTypes.string])


### PR DESCRIPTION
## Summary
- make CodeEditor language prop optional
- configure ESLint to detect React version

## Testing
- `npm run lint`
- `npm test` *(fails: No test files found)*
- `npm run test:ui` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_b_68b6eb5b7f00832aa36218049a67e0c6