### PR TITLE
refactor: use default params in CodeEditor

### DIFF
--- a/ui/src/components/CodeEditor.jsx
+++ b/ui/src/components/CodeEditor.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Editor, DiffEditor } from '@monaco-editor/react';
 
-const CodeEditor = ({ original, modified, language = 'javascript', height }) => {
+const CodeEditor = ({ original = '', modified = '', language = 'javascript', height = 400 }) => {
   if (modified) {
     return (
       <DiffEditor
@@ -31,10 +31,4 @@ CodeEditor.propTypes = {
   modified: PropTypes.string,
   height: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
 };
-CodeEditor.defaultProps = {
-  original: '',
-  modified: '',
-  height: 400
-};
-
 export default CodeEditor;


### PR DESCRIPTION
## Summary
- refactor CodeEditor to use default parameters instead of defaultProps

## Testing
- `npm test` (fails: document is not defined)
- `npm run test:ui`

------
https://chatgpt.com/codex/tasks/task_b_68b6f59050c8832aa945687bd924d329