### PR TITLE
chore: configure vitest setup

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -53,5 +53,11 @@
     "typescript": "^5.5.4",
     "vite": "^7.0.2",
     "vitest": "^2.1.9"
+  },
+  "vitest": {
+    "setupFiles": [
+      "./vitest.setup.js"
+    ],
+    "environment": "jsdom"
   }
 }

--- a/ui/vitest.setup.js
+++ b/ui/vitest.setup.js
@@ -1,0 +1,9 @@
+import '@testing-library/jest-dom';
+
+const originalError = console.error;
+console.error = (...args) => {
+  if (typeof args[0] === 'string' && args[0].includes('ReactDOM.render is no longer supported in React 18')) {
+    return;
+  }
+  originalError(...args);
+};


### PR DESCRIPTION
## Summary
- add Vitest setup file importing jest-dom and silencing React 18 deprecation noise
- configure Vitest to load setup file and use jsdom environment

## Testing
- `cd ui && npm test` *(fails: document is undefined)*

------
https://chatgpt.com/codex/tasks/task_b_68b6f67591fc832a91d6175456d61592