### PR TITLE
chore: enforce Node engine strictness

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true


### PR DESCRIPTION
## Summary
- add `.npmrc` to enforce Node version compatibility via `engine-strict=true`

## Testing
- `SKIP=eslint,prettier pre-commit run --files .npmrc`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b7040af31c832ababead58c4237c06