### PR TITLE
ci: use .nvmrc for node version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Use Node 22.x
         uses: actions/setup-node@v4
         with:
-          node-version: '22.x'
+          node-version-file: '.nvmrc'
           cache: 'npm'
           cache-dependency-path: ui/package-lock.json
       - name: Install


### PR DESCRIPTION
## Summary
- use `.nvmrc` to configure Node version in CI workflow

## Testing
- `SKIP=eslint,prettier pre-commit run --files .github/workflows/ci.yml`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b705212ad8832a9f0d77046236dfc9