### PR TITLE
fix(ui): disable vitest watch mode

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -11,8 +11,8 @@
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
     "lint": "eslint \"src/**/*.{js,jsx}\"",
-    "test:ui": "vitest --environment jsdom",
-    "test": "npm run test:ui"
+    "test:ui": "vitest --environment jsdom --run",
+    "test": "vitest --environment jsdom --run"
   },
   "dependencies": {
     "@emotion/react": "^11.11.3",


### PR DESCRIPTION
## Summary
- run vitest in run mode for ui tests to avoid watch behavior

## Testing
- `cd ui && npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b70bd225c8832abee45fb2faa0bd58