### PR TITLE
chore: explicitly set manifest command

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -23,3 +23,4 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          command: manifest


### PR DESCRIPTION
## Summary
- explicitly invoke manifest mode in release-please workflow

## Testing
- `pre-commit run --files .github/workflows/release-please.yml` *(fails: node prebuilt download issue)*

------
https://chatgpt.com/codex/tasks/task_b_68b71be9c834832a845dca7c4c6b2298