### PR TITLE
chore: ensure node_modules are ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,8 @@ __pycache__/
 .env
 .vscode/
 **/__pycache__/
+# Ignore Node.js dependencies
 node_modules/
+
+# Built UI output
 ui/dist/


### PR DESCRIPTION
## Summary
- remove `ui/node_modules` directory from repo and keep it ignored
- document ignore rule for Node.js dependencies

## Testing
- `pre-commit run --files .gitignore` *(failed: Failed to download prebuilt Node 22, causing nodeenv error)*

------
https://chatgpt.com/codex/tasks/task_b_68b71d72df00832a94abc8511bb96a55