### PR TITLE
chore: configure pre-major bump for ui package

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,7 +7,9 @@
       "release-type": "node",
       "package-name": "naestro-ui",
       "changelog-path": "ui/CHANGELOG.md",
-      "versioning": "default"
+      "versioning": "default",
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true
     }
   }
 }


### PR DESCRIPTION
## Summary
- configure release-please to bump minor and patch versions prior to v1.0 for the ui package

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68b71f08a554832a8e263d31acf9c053