### PR TITLE
Ignore nested node_modules directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ __pycache__/
 **/__pycache__/
 # Ignore Node.js dependencies
 node_modules/
+**/node_modules/
 
 # Built UI output
 ui/dist/


### PR DESCRIPTION
## Summary
- ignore node_modules directories at any depth

## Testing
- `pre-commit run --files .gitignore` *(fails: not enough values to unpack for Node 22 prebuild)*

------
https://chatgpt.com/codex/tasks/task_b_68b720cff894832aa247ef216d2a19fb