### PR TITLE
chore(ui): add test:ci script

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -12,6 +12,7 @@
     "typecheck": "tsc --noEmit",
     "lint": "eslint \"src/**/*.{js,jsx}\"",
     "test:ui": "vitest --environment jsdom --run",
+    "test:ci": "vitest --environment jsdom --run",
     "test": "vitest --environment jsdom --run"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- add `test:ci` script to run vitest with jsdom in CI

## Testing
- `npm run test:ci`
- `pre-commit run --files ui/package.json` *(fails: Failed to download from https://nodejs.org/download/release/v22/node-v22-linux-x64.tar.gz)*


------
https://chatgpt.com/codex/tasks/task_b_68b72207b698832a9e9213ec984144c5