### PR TITLE
chore: disable component in release tag

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,6 @@
 {
   "bootstrap-sha": "",
-  "include-component-in-tag": true,
+  "include-component-in-tag": false,
   "packages": {
     "ui": {
       "path": "ui",


### PR DESCRIPTION
## Summary
- disable `include-component-in-tag` so release tags omit the component name

## Testing
- `pre-commit run --files release-please-config.json` *(failed: Install prebuilt node (22) - Failed to download from https://nodejs.org/download/release/v22/node-v22-linux-x64.tar.gz)*

------
https://chatgpt.com/codex/tasks/task_b_68b72525a194832a854b6877c281c942