### PR TITLE
ci: restrict workflow to ui

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,6 @@ jobs:
   ui:
     name: UI (lint • typecheck • build • test)
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ui
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -22,14 +19,19 @@ jobs:
           cache: 'npm'
           cache-dependency-path: ui/package-lock.json
       - name: Install
+        working-directory: ui
         run: npm ci
       - name: Lint
+        working-directory: ui
         run: npm run lint --if-present
       - name: Typecheck
+        working-directory: ui
         run: npm run typecheck --if-present
       - name: Build
+        working-directory: ui
         run: npm run build --if-present
       - name: Test (jsdom)
+        working-directory: ui
         env:
           CI: 'true'
         run: |


### PR DESCRIPTION
## Summary
- simplify CI to only run UI tasks
- execute all job steps from `ui` directory

## Testing
- `SKIP=eslint,prettier pre-commit run --files .github/workflows/ci.yml`
- `cd ui && npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b728252750832a89939e2b61abc226