### PR TITLE
ci: add PR title validation workflow

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,20 @@
+name: PR Title
+
+on:
+  pull_request_target:
+
+permissions:
+  pull-requests: write
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: amannn/action-semantic-pull-request@v5
+        with:
+          autoFix: true
+          config: commitlint.config.cjs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+


### PR DESCRIPTION
## Summary
- add semantic PR title check workflow using amannn/action-semantic-pull-request@v5 with auto-fix

## Testing
- `SKIP=eslint,prettier pre-commit run --files .github/workflows/pr-title.yml`

------
https://chatgpt.com/codex/tasks/task_b_68b72cd48868832a83304be96c3b197a