### PR TITLE
chore: configure dependabot for UI package

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,9 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule: { interval: "weekly" }
+  - package-ecosystem: "npm"
+    directory: "/ui"
+    schedule: { interval: "weekly" }
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule: { interval: "weekly" }


### PR DESCRIPTION
## Summary
- add dependabot entry to update npm deps in `/ui`

## Testing
- `pre-commit run --files .github/dependabot.yml` *(fails: nodeenv could not download Node 22)*

------
https://chatgpt.com/codex/tasks/task_b_68b73dfd24ec832a9f4ee899b3b4e53b