### PR TITLE
feat: sanitize sympy usage in math agent

### DIFF
--- a/src/orchestrator/math_agent.py
+++ b/src/orchestrator/math_agent.py
@@ -6,7 +6,51 @@ from langgraph.graph import StateGraph
 from scipy import integrate
 
 
+# Allowed symbols and functions for safe evaluation
 x = sp.symbols("x")
+ALLOWED_NAMES = {
+    "x": x,
+    "pi": sp.pi,
+    "sin": sp.sin,
+    "cos": sp.cos,
+    "tan": sp.tan,
+    "log": sp.log,
+    "exp": sp.exp,
+    "sqrt": sp.sqrt,
+}
+
+# Regular expressions for validating user supplied expressions
+_ALLOWED_CHAR_RE = re.compile(r"^[0-9a-zA-Z+\-*/^().,\s]*$")
+_TOKEN_RE = re.compile(r"[A-Za-z]+")
+
+
+def _validate_expr(expr: str) -> None:
+    """Validate that an expression contains only whitelisted tokens.
+
+    Parameters
+    ----------
+    expr: str
+        The expression string to validate.
+
+    Raises
+    ------
+    ValueError
+        If the expression contains invalid characters or tokens.
+    """
+
+    if not _ALLOWED_CHAR_RE.fullmatch(expr):
+        raise ValueError("Invalid characters in expression")
+
+    for token in _TOKEN_RE.findall(expr):
+        if token not in ALLOWED_NAMES:
+            raise ValueError(f"Invalid token: {token}")
+
+
+def _safe_sympify(expr: str) -> sp.Expr:
+    """Safely convert a string expression to a SymPy expression."""
+
+    _validate_expr(expr)
+    return sp.sympify(expr, locals=ALLOWED_NAMES, evaluate=False)
 
 def parse_math_query(query: str) -> Any:
     """Parse a math query and execute it using SymPy/SciPy.
@@ -24,33 +68,33 @@ def parse_math_query(query: str) -> Any:
     m = re.match(r"integrate\s+(.+)\s+from\s+(.+)\s+to\s+(.+)", query, re.I)
     if m:
         expr, lower, upper = m.groups()
-        func = sp.lambdify(x, sp.sympify(expr), "math")
-        a = float(sp.sympify(lower))
-        b = float(sp.sympify(upper))
+        func = sp.lambdify(x, _safe_sympify(expr), "math")
+        a = float(_safe_sympify(lower))
+        b = float(_safe_sympify(upper))
         val, _ = integrate.quad(func, a, b)
         return val
 
     m = re.match(r"integrate\s+(.+)", query, re.I)
     if m:
         expr = m.group(1)
-        return sp.integrate(sp.sympify(expr), x)
+        return sp.integrate(_safe_sympify(expr), x)
 
     m = re.match(r"(differentiate|derive)\s+(.+)", query, re.I)
     if m:
         expr = m.group(2)
-        return sp.diff(sp.sympify(expr), x)
+        return sp.diff(_safe_sympify(expr), x)
 
     m = re.match(r"solve\s+(.+)", query, re.I)
     if m:
         expr = m.group(1)
-        return sp.solve(sp.sympify(expr), x)
+        return sp.solve(_safe_sympify(expr), x)
 
     m = re.match(r"simplify\s+(.+)", query, re.I)
     if m:
         expr = m.group(1)
-        return sp.simplify(sp.sympify(expr))
+        return sp.simplify(_safe_sympify(expr))
 
-    return sp.simplify(sp.sympify(query))
+    return sp.simplify(_safe_sympify(query))
 
 def math_agent_fn(state: Dict[str, Any]) -> Dict[str, Any]:
     query = state.get("query", "")

--- a/tests/test_math_agent.py
+++ b/tests/test_math_agent.py
@@ -26,3 +26,18 @@ def test_parse_definite_integral():
 def test_math_app_invoke():
     res = math_app.invoke({"query": "differentiate x**2"})
     assert str(res["result"]) == "2*x"
+
+
+def test_invalid_symbol_rejected():
+    with pytest.raises(ValueError):
+        parse_math_query("solve y + 1")
+
+
+def test_malicious_expression_rejected():
+    with pytest.raises(ValueError):
+        parse_math_query("__import__('os')")
+
+
+def test_invalid_integral_bound():
+    with pytest.raises(ValueError):
+        parse_math_query("integrate x from 0 to y")


### PR DESCRIPTION
## Summary
- add whitelist validation and safe `sympify` wrapper for math queries
- restrict SymPy evaluation to approved names only
- test malformed and malicious expressions

## Testing
- `pytest tests/test_math_agent.py`

------
https://chatgpt.com/codex/tasks/task_b_68b745524708832abfabd7a0ab8b313e