### PR TITLE
Raise explicit error for missing NLTK corpora

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ curl http://localhost:8081/health
 ```bash
 pip install -r requirements.lock
 pip install -r scripts/requirements.txt  # utilities like governor.py
+python scripts/install_nltk_data.py      # download NLTK corpora
 
 # Start services directly (hot reload)
 uvicorn src.orchestrator.main:app --reload --port 8081 &

--- a/scripts/install_nltk_data.py
+++ b/scripts/install_nltk_data.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+"""Download required NLTK corpora for Naestro orchestrator."""
+
+import nltk
+
+
+def main() -> None:
+    nltk.download("punkt")
+    nltk.download("averaged_perceptron_tagger")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/orchestrator/orchestrator.py
+++ b/src/orchestrator/orchestrator.py
@@ -29,18 +29,12 @@ def ensure_nltk_data() -> None:
             missing.append(pkg)
 
     if missing:
-        for pkg in missing:
-            nltk.download(pkg, quiet=True)
-
-        unresolved = []
-        for pkg, path in packages.items():
-            try:
-                nltk.data.find(path)
-            except LookupError:
-                unresolved.append(pkg)
-
-        if unresolved:
-            raise LookupError("Missing NLTK corpora: " + ", ".join(sorted(unresolved)))
+        corpora = ", ".join(sorted(missing))
+        raise LookupError(
+            f"Missing NLTK corpora: {corpora}. "
+            "Run 'python scripts/install_nltk_data.py' or "
+            f"python -m nltk.downloader {corpora} before running."
+        )
 
     _NLTK_READY = True
 
@@ -110,9 +104,7 @@ def verify_fn(state):
 
         try:
             result = subprocess.run(["flake8", path], capture_output=True, text=True)
-            lint_errors = [
-                line for line in result.stdout.splitlines() if line.strip()
-            ]
+            lint_errors = [line for line in result.stdout.splitlines() if line.strip()]
             lint_delta = 1 / (1 + len(lint_errors))
         except FileNotFoundError:
             lint_delta = 0.0


### PR DESCRIPTION
## Summary
- raise clear `LookupError` when NLTK corpora are missing instead of downloading at runtime
- add `scripts/install_nltk_data.py` and document NLTK data pre-install step
- test `ensure_nltk_data` error path for missing corpora

## Testing
- `SKIP=eslint,prettier pre-commit run --files src/orchestrator/orchestrator.py scripts/install_nltk_data.py README.md tests/test_orchestrator.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68b7455321e4832a8efabeffb566ae5a