### PR TITLE
feat(math): make SciPy optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,14 @@ uvicorn src.orchestrator.main:app --reload --port 8081 &
 uvicorn src.gateway.main:app --reload --port 8080 &
 ```
 
+SciPy is optional and only needed for numeric integration in the math agent. When
+it's missing, Naestro falls back to a pure SymPy evaluator. Install SciPy
+separately if you want the faster `quad` integrator:
+
+```bash
+pip install scipy
+```
+
 Dependencies are pinned for reproducibility. After editing any `requirements.txt`,
 regenerate the corresponding `*.lock` file with `pip-compile`.
 

--- a/tests/test_math_agent.py
+++ b/tests/test_math_agent.py
@@ -1,6 +1,9 @@
+import builtins
+
 import pytest
 
-from src.orchestrator.math_agent import app as math_app, parse_math_query
+from src.orchestrator.math_agent import app as math_app
+from src.orchestrator.math_agent import parse_math_query
 
 
 def test_parse_integrate_symbolic():
@@ -19,6 +22,19 @@ def test_parse_solve():
 
 
 def test_parse_definite_integral():
+    result = parse_math_query("integrate sin(x) from 0 to pi")
+    assert result == pytest.approx(2.0, rel=1e-6)
+
+
+def test_parse_definite_integral_no_scipy(monkeypatch):
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name.startswith("scipy"):
+            raise ImportError("SciPy is not installed")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
     result = parse_math_query("integrate sin(x) from 0 to pi")
     assert result == pytest.approx(2.0, rel=1e-6)
 


### PR DESCRIPTION
## Summary
- defer SciPy import in math agent and fall back to SymPy when absent
- cover SciPy-less numeric integration in tests
- mention optional SciPy install in README

## Testing
- `SKIP=eslint,prettier pre-commit run --files src/orchestrator/math_agent.py tests/test_math_agent.py README.md`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b745518ba0832a9ef0a7347c826fb1