### PR TITLE
feat: expose real telemetry metrics

### DIFF
--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -55,6 +55,29 @@ echo $ORCH_URL  # expect: http://localhost:8081
 - **Inference Tier** – optional NIM, vLLM, and small model services.
 - **Monitoring Stack** – optional Prometheus + Grafana via the `monitoring` profile.
 
+## Telemetry API
+The gateway exposes real-time telemetry for system health and performance.
+
+| Endpoint | Description |
+|----------|-------------|
+| `/ws` | WebSocket stream emitting telemetry events. |
+| `/events` | Server-Sent Events fallback with the same payloads. |
+| `/api/metrics/system` | Latest CPU and memory usage. |
+| `/api/metrics/kpis` | Runtime KPIs derived from request handling. |
+
+Each streamed telemetry message shares this schema:
+
+```json
+{
+  "timestamp": 1712345678.9,
+  "system": {"cpu_percent": 42.5, "memory_mb": 1234.0},
+  "kpis": {"latency_p95_ms": 10.0, "throughput_rps": 0.5}
+}
+```
+
+Clients should subscribe to either `/ws` or `/events` and parse the `system` and `kpis`
+objects for monitoring or visualization.
+
 ## End-to-End Orchestration Demo
 1. Ensure gateway and orchestrator services are running (see `docker compose up` in Setup).
 2. Submit a task through the gateway:

--- a/src/gateway/main.py
+++ b/src/gateway/main.py
@@ -1,13 +1,56 @@
+"""Gateway service exposing orchestration and telemetry APIs."""
+
 import asyncio
+import logging
 import os
+import statistics
 import time
+from typing import List
 
 import httpx
 from fastapi import FastAPI, WebSocket
 from fastapi.responses import JSONResponse, StreamingResponse
+from pydantic import BaseModel
 
 app = FastAPI(title="NAESTRO Gateway")
 ORCH = os.getenv("ORCH_URL", "http://orchestrator:8081")
+
+logger = logging.getLogger(__name__)
+
+
+class SystemMetrics(BaseModel):
+    """CPU and memory usage sampled from the host system."""
+
+    cpu_percent: float
+    memory_mb: float
+
+
+class KPIMetrics(BaseModel):
+    """Application KPIs collected during runtime."""
+
+    latency_p95_ms: float
+    throughput_rps: float
+
+
+class Telemetry(BaseModel):
+    """Telemetry event emitted to streaming clients.
+
+    Schema::
+        {
+            "timestamp": <float>,
+            "system": {"cpu_percent": <float>, "memory_mb": <float>},
+            "kpis": {"latency_p95_ms": <float>, "throughput_rps": <float>}
+        }
+    """
+
+    timestamp: float
+    system: SystemMetrics
+    kpis: KPIMetrics
+
+
+REQUEST_LATENCIES: List[float] = []
+REQUEST_COUNT = 0
+START_TIME = time.time()
 
 
 @app.get("/health")
@@ -17,6 +60,10 @@ def health():
 
 @app.post("/orchestrate")
 async def orchestrate(task: dict):
+    """Proxy task execution to the orchestrator."""
+
+    global REQUEST_COUNT, REQUEST_LATENCIES
+    start = time.perf_counter()
     async with httpx.AsyncClient(timeout=120) as client:
         try:
             r = await client.post(f"{ORCH}/run", json=task)
@@ -26,17 +73,54 @@ async def orchestrate(task: dict):
             return JSONResponse(
                 {"error": "orchestrator unreachable"}, status_code=502
             )
+        finally:
+            duration_ms = (time.perf_counter() - start) * 1000
+            REQUEST_LATENCIES.append(duration_ms)
+            REQUEST_COUNT += 1
+
+
+def _system_metrics() -> SystemMetrics:
+    try:  # pragma: no cover - psutil may not be installed
+        import psutil  # type: ignore
+
+        cpu = psutil.cpu_percent(interval=None)
+        mem = psutil.virtual_memory().used / (1024 * 1024)
+        return SystemMetrics(cpu_percent=cpu, memory_mb=mem)
+    except Exception as exc:  # pragma: no cover - telemetry not available
+        logger.debug("System metrics unavailable: %s", exc)
+        return SystemMetrics(cpu_percent=0.0, memory_mb=0.0)
+
+
+def _kpi_metrics() -> KPIMetrics:
+    p95 = 0.0
+    if len(REQUEST_LATENCIES) >= 2:
+        p95 = statistics.quantiles(
+            REQUEST_LATENCIES, n=100, method="inclusive"
+        )[94]
+    elif REQUEST_LATENCIES:
+        p95 = REQUEST_LATENCIES[0]
+    elapsed = time.time() - START_TIME
+    throughput = REQUEST_COUNT / elapsed if elapsed > 0 else 0.0
+    return KPIMetrics(latency_p95_ms=p95, throughput_rps=throughput)
+
+
+def _telemetry_event() -> Telemetry:
+    return Telemetry(
+        timestamp=time.time(),
+        system=_system_metrics(),
+        kpis=_kpi_metrics(),
+    )
 
 
 @app.websocket("/ws")
 async def websocket_endpoint(websocket: WebSocket):
-    """WebSocket stream emitting heartbeats every 20 seconds."""
+    """WebSocket stream emitting system and KPI telemetry every 20 seconds."""
 
     await websocket.accept()
     try:
         while True:
-            # TODO: replace heartbeat with real telemetry events
-            await websocket.send_json({"heartbeat": time.time()})
+            event = _telemetry_event()
+            await websocket.send_json(event.model_dump())
             await asyncio.sleep(20)
     except Exception:  # pragma: no cover - connection dropped
         await websocket.close()
@@ -44,28 +128,26 @@ async def websocket_endpoint(websocket: WebSocket):
 
 @app.get("/events")
 async def sse_endpoint():
-    """Server‑Sent Events fallback emitting heartbeats every 20 seconds."""
+    """Server‑Sent Events fallback emitting telemetry every 20 seconds."""
 
     async def event_generator():
         while True:
-            # TODO: replace heartbeat with real telemetry events
-            yield f'data: {{"heartbeat": {time.time()}}}\n\n'
+            event = _telemetry_event()
+            yield f"data: {event.model_dump_json()}\n\n"
             await asyncio.sleep(20)
 
     return StreamingResponse(event_generator(), media_type="text/event-stream")
 
 
-@app.get("/api/metrics/system")
-def system_metrics():
-    """Return mock system metrics."""
+@app.get("/api/metrics/system", response_model=SystemMetrics)
+def system_metrics() -> SystemMetrics:
+    """Return current CPU and memory usage."""
 
-    # TODO: replace mock data with real system metrics
-    return {"cpu": 0.42, "memory": 1234}
+    return _system_metrics()
 
 
-@app.get("/api/metrics/kpis")
-def kpi_metrics():
-    """Return mock KPI metrics."""
+@app.get("/api/metrics/kpis", response_model=KPIMetrics)
+def kpi_metrics() -> KPIMetrics:
+    """Return runtime KPI statistics."""
 
-    # TODO: replace mock data with real KPI metrics
-    return {"latency_p95_ms": 250, "throughput_rps": 99}
+    return _kpi_metrics()

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -1,5 +1,6 @@
 import httpx
 from fastapi.testclient import TestClient
+import json
 
 from src.gateway.main import app
 
@@ -22,6 +23,8 @@ def test_orchestrate(monkeypatch):
             return response_payload
 
     class DummyAsyncClient:
+        def __init__(self, *args, **kwargs):
+            pass
         def __init__(self, *args, **kwargs):
             pass
 
@@ -47,6 +50,8 @@ def test_orchestrate_connection_error(monkeypatch):
     """Return 502 when orchestrator is unreachable."""
 
     class DummyAsyncClient:
+        def __init__(self, *args, **kwargs):
+            pass
         def __init__(self, *args, **kwargs):
             pass
 
@@ -77,3 +82,77 @@ def test_unknown_route():
     client = TestClient(app)
     resp = client.get("/doesnotexist")
     assert resp.status_code == 404
+
+
+def test_system_metrics():
+    client = TestClient(app)
+    resp = client.get("/api/metrics/system")
+    data = resp.json()
+    assert resp.status_code == 200
+    assert set(data.keys()) == {"cpu_percent", "memory_mb"}
+
+
+def test_kpi_metrics(monkeypatch):
+    class DummyResponse:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"ok": True}
+
+    class DummyAsyncClient:
+        def __init__(self, *args, **kwargs):
+            pass
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+        async def post(self, url, json):
+            return DummyResponse()
+
+    monkeypatch.setattr(httpx, "AsyncClient", DummyAsyncClient)
+    client = TestClient(app)
+    client.post("/orchestrate", json={"task": "demo"})  # generate metrics
+    resp = client.get("/api/metrics/kpis")
+    data = resp.json()
+    assert resp.status_code == 200
+    assert set(data.keys()) == {"latency_p95_ms", "throughput_rps"}
+
+
+def test_telemetry_streams(monkeypatch):
+    class DummyResponse:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"ok": True}
+
+    class DummyAsyncClient:
+        def __init__(self, *args, **kwargs):
+            pass
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+        async def post(self, url, json):
+            return DummyResponse()
+
+    monkeypatch.setattr(httpx, "AsyncClient", DummyAsyncClient)
+    client = TestClient(app)
+
+    with client.websocket_connect("/ws") as ws:
+        ws_data = ws.receive_json()
+
+    with client.stream("GET", "/events") as resp:
+        for line in resp.iter_lines():
+            if line:
+                assert line.startswith("data: ")
+                sse_data = json.loads(line[6:])
+                break
+
+    assert set(ws_data.keys()) == {"timestamp", "system", "kpis"}
+    assert ws_data.keys() == sse_data.keys()


### PR DESCRIPTION
## Summary
- stream real system and KPI telemetry over WebSocket and SSE
- gather CPU, memory and request KPIs for metrics endpoints
- document telemetry schema and add coverage for new endpoints

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b745449dd4832a8e3559db5490570d