### PR TITLE
test: ensure parse_math_query handles missing SciPy

### DIFF
--- a/tests/test_math_agent.py
+++ b/tests/test_math_agent.py
@@ -1,3 +1,4 @@
+import builtins
 import pytest
 
 from src.orchestrator.math_agent import app as math_app, parse_math_query
@@ -19,6 +20,20 @@ def test_parse_solve():
 
 
 def test_parse_definite_integral():
+    result = parse_math_query("integrate sin(x) from 0 to pi")
+    assert result == pytest.approx(2.0, rel=1e-6)
+
+
+def test_parse_definite_integral_without_scipy(monkeypatch):
+    original_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "scipy" or name.startswith("scipy."):
+            raise ImportError
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
     result = parse_math_query("integrate sin(x) from 0 to pi")
     assert result == pytest.approx(2.0, rel=1e-6)
 


### PR DESCRIPTION
## Summary
- test fallback to sympy when SciPy cannot be imported

## Testing
- `pre-commit run --files tests/test_math_agent.py` *(fails: Install prebuilt node (22) Failed to download)*
- `pytest tests/test_math_agent.py`

------
https://chatgpt.com/codex/tasks/task_b_68b74fd4b1d4832abb096528eb321afe