### PR TITLE
test: assert CodeEditor labels

### DIFF
--- a/ui/src/components/CodeEditor.test.jsx
+++ b/ui/src/components/CodeEditor.test.jsx
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import React from 'react';
+import ReactDOMServer from 'react-dom/server';
+import CodeEditor from './CodeEditor';
+
+describe('CodeEditor', () => {
+  it('renders labels for original and modified code', () => {
+    const html = ReactDOMServer.renderToStaticMarkup(
+      <CodeEditor original="foo" modified="bar" language="python" />
+    );
+
+    expect(html).toContain('Original (python)');
+    expect(html).toContain('Modified (python)');
+  });
+});


### PR DESCRIPTION
## Summary
- test that CodeEditor renders Original and Modified labels

## Testing
- `cd ui && npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b7d569f494832a96a9fb0e665ca1ed