### PR TITLE
chore(ui): configure vitest coverage reports

### DIFF
--- a/ui/vitest.config.mjs
+++ b/ui/vitest.config.mjs
@@ -11,6 +11,7 @@ export default defineConfig({
     watch: false,
     coverage: {
       provider: 'v8',
+      reporter: ['text', 'lcov'],
       reportsDirectory: '../coverage'
     }
   }


### PR DESCRIPTION
## Summary
- add vitest coverage reporters for text and lcov outputs
- keep coverage output path

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68b7d9f17db4832ab33a73878b81b199