### PR TITLE
chore: configure Codecov for monorepo

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,8 +1,31 @@
+codecov:
+  notify:
+    after_n_builds: 3
+    wait_for_ci: true
 coverage:
   status:
     project:
       default:
         target: auto
+        threshold: 2%
     patch:
       default:
         target: auto
+        threshold: 2%
+
+flags:
+  ui:
+    paths:
+      - ui/
+  server:
+    paths:
+      - server/
+  python:
+    paths:
+      - src/
+
+ignore:
+  - "tests/**"
+  - "docs/**"
+  - "scripts/**"
+  - "**/node_modules/**"


### PR DESCRIPTION
## Summary
- configure Codecov with flags for ui, server, and python
- set gentle coverage thresholds and ignore tests, docs, scripts, and node_modules

## Testing
- `SKIP=eslint,prettier pre-commit run --files codecov.yml`

------
https://chatgpt.com/codex/tasks/task_b_68b7e1019c24832aab31c91edfbf9291