### PR TITLE
chore: expand CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,14 +49,74 @@ jobs:
           path: ui/node_modules/.vite
           key: ${{ runner.os }}-vite-${{ hashFiles('ui/package-lock.json') }}
 
-      - name: Test with coverage
-        env:
-          CI: 'true'
-        run: npm run test:coverage
+        - name: Test with coverage
+          env:
+            CI: 'true'
+          run: npm run test:coverage
 
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          flags: ui
-          directory: coverage
+        - name: Upload coverage to Codecov
+          uses: codecov/codecov-action@v5
+          with:
+            token: ${{ secrets.CODECOV_TOKEN }}
+            flags: ui
+            directory: coverage
+
+    server:
+      name: Server (Node 22.x)
+      runs-on: ubuntu-latest
+      if: hashFiles('server/package.json') != ''
+      defaults:
+        run:
+          working-directory: server
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+
+        - name: Use Node 22.x
+          uses: actions/setup-node@v4
+          with:
+            node-version: '22.x'
+            cache: 'npm'
+            cache-dependency-path: 'server/package-lock.json'
+
+        - name: Install
+          run: npm ci
+
+        - name: Test with coverage
+          env:
+            CI: 'true'
+          run: npm run test:coverage
+
+        - name: Upload coverage to Codecov
+          uses: codecov/codecov-action@v5
+          with:
+            token: ${{ secrets.CODECOV_TOKEN }}
+            flags: server
+            directory: coverage
+
+    python:
+      name: Python (3.11)
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+
+        - name: Set up Python
+          uses: actions/setup-python@v5
+          with:
+            python-version: '3.11'
+
+        - name: Install dependencies
+          run: |
+            python -m pip install --upgrade pip
+            pip install -r requirements.lock -r src/gateway/requirements.lock -r src/orchestrator/requirements.lock pytest pytest-cov
+
+        - name: Test with coverage
+          run: pytest --cov=src --cov-report=xml
+
+        - name: Upload coverage to Codecov
+          uses: codecov/codecov-action@v5
+          with:
+            token: ${{ secrets.CODECOV_TOKEN }}
+            files: coverage.xml
+            flags: python


### PR DESCRIPTION
## Summary
- upgrade Codecov upload to v5 and flag UI coverage
- add conditional server job to test and upload coverage
- add Python job running pytest with coverage

## Testing
- `SKIP=eslint,prettier pre-commit run --files .github/workflows/ci.yml`
- `pytest tests/test_examples.py --cov=src --cov-report=xml`


------
https://chatgpt.com/codex/tasks/task_b_68b7e22abf30832a82e1a056773ea675