### PR TITLE
Add smoke test and configure coverage output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
             pip install -r requirements.lock -r src/gateway/requirements.lock -r src/orchestrator/requirements.lock pytest pytest-cov
 
         - name: Test with coverage
-          run: pytest --cov=src --cov-report=xml
+          run: pytest --cov=src --cov-report=xml:coverage.xml
 
         - name: Upload coverage to Codecov
           uses: codecov/codecov-action@v5

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,5 @@
+from src.gateway.main import health
+
+
+def test_health_ok():
+    assert health() == {"status": "ok"}


### PR DESCRIPTION
## Summary
- add a simple gateway smoke test for the `/health` handler
- configure Python CI job to write coverage report to `coverage.xml`

## Testing
- `pytest tests/test_smoke.py --cov=src --cov-report=xml:coverage.xml`

------
https://chatgpt.com/codex/tasks/task_b_68b7ec9e77c4832abe116a8ec5b14a16