### PR TITLE
chore: enforce full coverage in codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,23 +6,23 @@ coverage:
   status:
     project:
       default:
-        target: auto
-        threshold: 2%
+        target: 100%
+        threshold: 0%
     patch:
       default:
-        target: auto
-        threshold: 2%
+        target: 100%
+        threshold: 0%
 
 flags:
   ui:
     paths:
-      - ui/
+      - ui/src
   server:
     paths:
-      - server/
+      - server/api
   python:
     paths:
-      - src/
+      - src
 
 ignore:
   - "tests/**"


### PR DESCRIPTION
## Summary
- enforce 100% coverage targets with zero threshold for project and patch
- scope coverage flags to package source directories

## Testing
- `pytest -q`
- `npm test` in `ui`
- `npm run test:ci` in `server`


------
https://chatgpt.com/codex/tasks/task_b_68b7f4ebb094832aabc9ff09f2c8ba0d