### PR TITLE
test(ui): enforce 100% coverage thresholds

### DIFF
--- a/ui/vitest.config.mjs
+++ b/ui/vitest.config.mjs
@@ -12,7 +12,20 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reporter: ['text', 'text-summary', 'lcov'],
-      reportsDirectory: 'coverage'
+      reportsDirectory: 'coverage',
+      all: true,
+      include: ['src/**/*.{js,jsx,ts,tsx}'],
+      exclude: [
+        'src/**/*.generated.{js,jsx,ts,tsx}',
+        'src/**/*.stories.{js,jsx,ts,tsx}',
+        'src/**/*.{setup,setupTests}.{js,jsx,ts,tsx}'
+      ],
+      thresholds: {
+        lines: 100,
+        functions: 100,
+        branches: 100,
+        statements: 100
+      }
     }
   }
 });


### PR DESCRIPTION
## Summary
- require full coverage for UI tests with explicit include/exclude rules

## Testing
- `npm test`
- `npm run lint`
- `npm run test:coverage` *(fails: Coverage for lines (84.23%) does not meet global threshold (100%))*

------
https://chatgpt.com/codex/tasks/task_b_68b7fa42d8d4832a9a2fbc85b34153c5