### PR TITLE
test: add routing and token utility tests

### DIFF
--- a/server/src/orchestrator/policy/__tests__/routing.spec.ts
+++ b/server/src/orchestrator/policy/__tests__/routing.spec.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { chooseRoute } from '../routing';
+
+describe('chooseRoute', () => {
+  it('uses local route when token count is below threshold and local route available', () => {
+    expect(chooseRoute({ tokens: 1500 })).toBe('local');
+  });
+
+  it('falls back to cloud when token count exceeds threshold', () => {
+    expect(chooseRoute({ tokens: 250000 })).toBe('cloud');
+  });
+
+  it('falls back to cloud when local route is unavailable', () => {
+    expect(chooseRoute({ tokens: 1500, localAvailable: false })).toBe('cloud');
+  });
+});

--- a/server/src/orchestrator/policy/routing.ts
+++ b/server/src/orchestrator/policy/routing.ts
@@ -1,0 +1,18 @@
+export type Route = 'local' | 'cloud';
+
+export interface RouteDecision {
+  tokens: number;
+  longContextThreshold?: number;
+  localAvailable?: boolean;
+}
+
+export function chooseRoute({
+  tokens,
+  longContextThreshold = 200000,
+  localAvailable = true
+}: RouteDecision): Route {
+  if (tokens > longContextThreshold) {
+    return 'cloud';
+  }
+  return localAvailable ? 'local' : 'cloud';
+}

--- a/server/src/utils/__tests__/token.spec.ts
+++ b/server/src/utils/__tests__/token.spec.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { estimateTokens } from '../token';
+
+describe('estimateTokens', () => {
+  it('estimates tokens for a single string', () => {
+    expect(estimateTokens('hello world')).toBe(2);
+  });
+
+  it('handles arrays of strings', () => {
+    expect(estimateTokens(['hello world', 'how are you'])).toBe(5);
+  });
+
+  it('returns 0 for empty input', () => {
+    expect(estimateTokens('')).toBe(0);
+    expect(estimateTokens([])).toBe(0);
+  });
+});

--- a/server/src/utils/token.ts
+++ b/server/src/utils/token.ts
@@ -1,0 +1,9 @@
+export type TextInput = string | string[];
+
+export function estimateTokens(input: TextInput): number {
+  const text = Array.isArray(input) ? input.join(' ') : input;
+  if (!text.trim()) {
+    return 0;
+  }
+  return text.trim().split(/\s+/).length;
+}


### PR DESCRIPTION
## Summary
- add deterministic routing policy tests for chooseRoute
- add token estimation tests for estimateTokens utility

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_b_68b802731f3c832a83cff98ec37b7a44