### PR TITLE
test: cover health handler and upload server coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,25 @@ jobs:
           files: ui/coverage/lcov.info
           flags: ui
           fail_ci_if_error: true
+  server:
+    runs-on: ubuntu-latest
+    container: node:22-bullseye
+    defaults: { run: { working-directory: server } }
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-server-npm-${{ hashFiles('server/package-lock.json') }}
+          restore-keys: ${{ runner.os }}-server-npm-
+      - run: npm ci
+      - run: npm run lint --if-present
+      - run: npm run build --if-present
+      - run: npm run test:ci --if-present
+        env: { CI: "true" }
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: server/coverage/lcov.info
+          flags: server
+          fail_ci_if_error: true

--- a/server/api/health.test.ts
+++ b/server/api/health.test.ts
@@ -3,16 +3,40 @@ import { describe, expect, it, vi } from 'vitest';
 import { healthHandler } from './health';
 
 describe('healthHandler', () => {
-  it('responds with ok', () => {
+  it('responds with version headers and full status payload', () => {
     const req = {} as Request;
     const setHeader = vi.fn();
     const json = vi.fn();
-
     const res = { setHeader, json } as unknown as Response;
 
-    healthHandler(req, res);
+    const prev = {
+      NAESTRO_VERSION: process.env.NAESTRO_VERSION,
+      NAESTRO_STUDIO_VERSION: process.env.NAESTRO_STUDIO_VERSION,
+      NAESTRO_PROVIDERS_SCHEMA: process.env.NAESTRO_PROVIDERS_SCHEMA,
+      GIT_SHA: process.env.GIT_SHA,
+    };
 
-    expect(setHeader).toHaveBeenCalledWith('X-Naestro-Version', expect.any(String));
-    expect(json).toHaveBeenCalledWith(expect.objectContaining({ ok: true }));
+    process.env.NAESTRO_VERSION = '1.2.3';
+    process.env.NAESTRO_STUDIO_VERSION = '4.5.6';
+    process.env.NAESTRO_PROVIDERS_SCHEMA = '7.8.9';
+    process.env.GIT_SHA = 'abcdefg';
+
+    try {
+      healthHandler(req, res);
+    } finally {
+      process.env.NAESTRO_VERSION = prev.NAESTRO_VERSION;
+      process.env.NAESTRO_STUDIO_VERSION = prev.NAESTRO_STUDIO_VERSION;
+      process.env.NAESTRO_PROVIDERS_SCHEMA = prev.NAESTRO_PROVIDERS_SCHEMA;
+      process.env.GIT_SHA = prev.GIT_SHA;
+    }
+
+    expect(setHeader).toHaveBeenCalledWith('X-Naestro-Version', '1.2.3');
+    expect(json).toHaveBeenCalledWith({
+      core: '1.2.3',
+      studio: '4.5.6',
+      providers_schema: '7.8.9',
+      git_sha: 'abcdefg',
+      ok: true,
+    });
   });
 });


### PR DESCRIPTION
## Summary
- broaden health endpoint test to verify version headers and full JSON payload
- run server tests in CI and upload coverage to Codecov using the `server` flag

## Testing
- `pre-commit run --files .github/workflows/ci.yml server/api/health.test.ts`
- `cd server && npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_b_68b803f0dde4832a96c6ce9a7bcb78ff