### PR TITLE
Add coverage configuration and Codecov upload

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,6 @@
+[run]
+source = src
+
+[report]
+show_missing = true
+fail_under = 100

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,3 +54,23 @@ jobs:
           files: server/coverage/lcov.info
           flags: server
           fail_ci_if_error: true
+  python:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt pytest pytest-cov
+      - name: Run tests
+        run: |
+          pytest --cov=src --cov-report=xml --cov-fail-under=100
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: coverage.xml
+          flags: python
+          fail_ci_if_error: true

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,8 @@ ui/dist/
 
 # Ignore nested UI directory
 ui/ui/
+
+# Coverage reports
+.coverage
+coverage.xml
+htmlcov/


### PR DESCRIPTION
## Summary
- add Python coverage config and ignore coverage artifacts
- run Python tests in CI with coverage and upload to Codecov

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -p pytest_cov --cov=src --cov-report=xml --cov-fail-under=100` *(failed: KeyboardInterrupt; 9 passed but process did not exit cleanly)*

------
https://chatgpt.com/codex/tasks/task_b_68b807ef3044832ab501ed3e945e3378