### PR TITLE
ci: show UI coverage files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,12 +26,17 @@ jobs:
       - run: npm run build --if-present
       - run: npm run test:ci --if-present
         env: { CI: "true" }
-      - name: Upload coverage to Codecov
+      - name: Show coverage files
+        run: |
+          ls -la ui/coverage || true
+          [ -f ui/coverage/lcov.info ] && head -n 20 ui/coverage/lcov.info || echo "lcov not found"
+      - name: Upload Codecov (UI)
         uses: codecov/codecov-action@v4
         with:
           files: ui/coverage/lcov.info
           flags: ui
           fail_ci_if_error: true
+          verbose: true
   server:
     runs-on: ubuntu-latest
     container: node:22-bullseye


### PR DESCRIPTION
## Summary
- show UI coverage files before upload
- use verbose Codecov upload step for UI job

## Testing
- `pre-commit run --files .github/workflows/ci.yml`

------
https://chatgpt.com/codex/tasks/task_b_68b816c8ab6c832ab25d0bc50aae6b28