### PR TITLE
build: enforce Node 22 usage

### DIFF
--- a/.github/workflows/commit-messages.yml
+++ b/.github/workflows/commit-messages.yml
@@ -14,10 +14,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Use Node 22.x
+      - name: Use Node 22
         uses: actions/setup-node@v4
         with:
-          node-version: '22.x'
+          node-version: 22
 
       - name: Lint commits in this push
         uses: wagoid/commitlint-github-action@v6

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -15,10 +15,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Use Node 22.x
+      - name: Use Node 22
         uses: actions/setup-node@v4
         with:
-          node-version: '22.x'
+          node-version: 22
 
       - name: Lint PR title
         uses: wagoid/commitlint-github-action@v6

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@
 
 ## Prerequisites
 
-- Node.js 22 (see `.node-version` and `.nvmrc`).
+ - Node.js 22 (see `.node-version` and `.nvmrc`; run `nvm use` or `fnm use` to switch automatically).
 
 ## Run the UI locally
 
@@ -23,8 +23,9 @@ The dev server runs on http://localhost:5173. Set `VITE_SOCKET_BASE_URL` if your
 
 We enforce ESLint/Prettier and other checks via [pre-commit](https://pre-commit.com/).
 
-- This repo uses **Node 22** everywhere (`.nvmrc`, `.node-version`).
-- To avoid `nodeenv` download issues, we configure pre-commit to use the **system Node**:
+ - This repo uses **Node 22** everywhere (`.nvmrc`, `.node-version`).
+ - Configure your shell to run `nvm use` or `fnm use` on entry so the correct version is loaded.
+ - To avoid `nodeenv` download issues, we configure pre-commit to use the **system Node**:
 
 ```yaml
 default_language_version:

--- a/server/package.json
+++ b/server/package.json
@@ -6,6 +6,7 @@
   "engines": {
     "node": ">=22 <23"
   },
+  "engineStrict": true,
   "scripts": {
     "lint": "tsc --noEmit",
     "build": "tsc -p tsconfig.json",

--- a/ui/package.json
+++ b/ui/package.json
@@ -6,6 +6,7 @@
   "engines": {
     "node": ">=22 <23"
   },
+  "engineStrict": true,
   "scripts": {
     "dev": "vite",
     "build": "vite build",


### PR DESCRIPTION
## Summary
- enforce strict Node 22 engines for UI and server packages
- pin GitHub Actions setup-node steps to Node 22
- document using Node 22 via `nvm use`/`fnm use`

## Testing
- `pre-commit run --files ui/package.json server/package.json .github/workflows/commit-messages.yml .github/workflows/pr-title.yml CONTRIBUTING.md`
- `npm test` (failed: expect(element).toHaveClass("MuiChip-colorSuccess"))
- `npm run test:ci`

------
https://chatgpt.com/codex/tasks/task_b_68b81cfbc9c8832a8a828afc533ccc96