### PR TITLE
test: migrate vitest setup to TypeScript

### DIFF
--- a/ui/src/setupTests.ts
+++ b/ui/src/setupTests.ts
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom/vitest';
-import { server } from './src/mocks/server';
+import { server } from './mocks/server';
 
 const originalError = console.error;
 console.error = (...args) => {

--- a/ui/vitest.config.mjs
+++ b/ui/vitest.config.mjs
@@ -6,10 +6,10 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'jsdom',
-    setupFiles: ['./vitest.setup.js'],
+    setupFiles: ['./src/setupTests.ts'],
     coverage: {
       include: ['src/**/*.{js,jsx,ts,tsx}'],
-      exclude: ['src/main.jsx', 'src/**/__tests__/**', 'src/setup.js'],
+      exclude: ['src/main.jsx', 'src/**/__tests__/**', 'src/setupTests.ts'],
       perFile: true,
       reporter: ['text', 'lcov', 'html'],
     },


### PR DESCRIPTION
## Summary
- move vitest setup file into src and convert to TypeScript
- point vitest config at src/setupTests.ts and ignore it for coverage

## Testing
- `npm run test:ci`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_68b822ecd034832aad971731a842777d