### PR TITLE
feat(ui): mock status and metrics endpoints

### DIFF
--- a/ui/src/mocks/handlers.js
+++ b/ui/src/mocks/handlers.js
@@ -1,13 +1,30 @@
 import { http, HttpResponse } from 'msw';
 
+// Mock API handlers used by dashboard components.
+// Add new endpoints here so tests remain deterministic.
 export const handlers = [
+  // Models listing for orchestrate flow
   http.get('/api/models', () => {
     return HttpResponse.json({ models: [] });
   }),
+
+  // Health check endpoint
   http.get('/api/health', () => {
     return HttpResponse.json({ status: 'ok' });
   }),
+
+  // Orchestrate action
   http.post('/api/orchestrate', () => {
     return HttpResponse.json({ id: 'mocked-id' });
+  }),
+
+  // ServiceStatus & LiveMonitor: service state snapshot
+  http.get('/api/status', () => {
+    return HttpResponse.json({ svc: 'ok' });
+  }),
+
+  // MetricsChart: initial metrics snapshot
+  http.get('/api/metrics', () => {
+    return HttpResponse.json({ time: 0, latency: 0, throughput: 0 });
   }),
 ];


### PR DESCRIPTION
## Summary
- document mock server endpoints
- add deterministic mocks for `/api/status` and `/api/metrics`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b822e9ad84832a922ec9d9a6673ebe