### PR TITLE
test: enforce full coverage

### DIFF
--- a/ui/vitest.config.mjs
+++ b/ui/vitest.config.mjs
@@ -8,10 +8,15 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: ['./src/setupTests.ts'],
     coverage: {
+      all: true,
       include: ['src/**/*.{js,jsx,ts,tsx}'],
-      exclude: ['src/main.jsx', 'src/**/__tests__/**', 'src/setupTests.ts'],
+      exclude: ['src/**/__tests__/**', 'src/setupTests.ts', 'src/main.jsx'],
       perFile: true,
       reporter: ['text', 'lcov', 'html'],
+      lines: 100,
+      statements: 100,
+      branches: 100,
+      functions: 100,
     },
   },
 });


### PR DESCRIPTION
## Summary
- enforce full coverage in Vitest config for ui
- include only src files while excluding tests, setup, and main entry
- require 100% coverage for lines, statements, branches, and functions

## Testing
- `npm test -- --run --coverage`

------
https://chatgpt.com/codex/tasks/task_b_68b8289039cc832aa9053abdd6d893f0