### PR TITLE
feat(ui): allow custom metric source for chart

### DIFF
--- a/ui/src/components/MetricsChart.jsx
+++ b/ui/src/components/MetricsChart.jsx
@@ -12,16 +12,58 @@ import {
 import io from "socket.io-client";
 import { SOCKET_BASE_URL } from "../config";
 
-const MetricsChart = () => {
+/**
+ * MetricsChart renders latency/throughput metrics.
+ *
+ * It optionally accepts a `getMetrics` function which can deterministically
+ * push metrics to the chart (used in tests or for alternative data sources).
+ * When omitted the component will subscribe to the default socket stream.
+ *
+ * @param {{getMetrics?: (emit: (m: any) => void) => (void|(() => void))}} props
+ */
+const MetricsChart = ({ getMetrics }) => {
   const [data, setData] = useState([]);
+  const [error, setError] = useState(false);
 
   useEffect(() => {
-    const socket = io(SOCKET_BASE_URL);
-    socket.on("metrics", (metrics) => {
-      setData((prev) => [...prev.slice(-19), metrics]);
-    });
-    return () => socket.close();
-  }, []);
+    let cleanup = () => {};
+
+    const emit = (metrics) => {
+      if (Array.isArray(metrics)) {
+        metrics.forEach((m) =>
+          setData((prev) => [...prev.slice(-19), m])
+        );
+      } else if (metrics) {
+        setData((prev) => [...prev.slice(-19), metrics]);
+      }
+    };
+
+    const setup = async () => {
+      try {
+        if (getMetrics) {
+          const result = await getMetrics(emit);
+          if (typeof result === "function") cleanup = result;
+        } else {
+          const socket = io(SOCKET_BASE_URL);
+          socket.on("metrics", emit);
+          socket.on("connect_error", () => setError(true));
+          cleanup = () => socket.close();
+        }
+      } catch {
+        setError(true);
+      }
+    };
+
+    setup();
+
+    return () => {
+      cleanup();
+    };
+  }, [getMetrics]);
+
+  if (error) {
+    return <div role="alert">Error loading metrics</div>;
+  }
 
   return (
     <ResponsiveContainer width="100%" height={300}>

--- a/ui/src/components/__tests__/__snapshots__/MetricsChart.test.jsx.snap
+++ b/ui/src/components/__tests__/__snapshots__/MetricsChart.test.jsx.snap
@@ -1,0 +1,36 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`MetricsChart > renders metrics with axes and legend 1`] = `
+<div>
+  <div
+    data-testid="container"
+  >
+    <div
+      data-points="1"
+      role="chart"
+    >
+      <div
+        role="grid"
+      />
+      <div
+        role="x-axis"
+      />
+      <div
+        role="y-axis"
+      />
+      <div
+        role="tooltip"
+      />
+      <div
+        role="legend"
+      />
+      <div
+        role="line-latency"
+      />
+      <div
+        role="line-throughput"
+      />
+    </div>
+  </div>
+</div>
+`;


### PR DESCRIPTION
## Summary
- allow MetricsChart to accept optional getMetrics function for deterministic or injected metrics streams
- add coverage for empty, populated, and error cases with lightweight recharts mocks

## Testing
- `cd ui && npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_b_68b828a90e38832a9729108be28c437c