### PR TITLE
ci: validate ui coverage paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,20 @@ jobs:
       - run: npm run build --if-present
       - run: npm run test:ci --if-present
         env: { CI: "true" }
-      - name: Show coverage files
+      - name: Verify coverage files
         run: |
-          ls -la ui/coverage || true
-          [ -f ui/coverage/lcov.info ] && head -n 20 ui/coverage/lcov.info || echo "lcov not found"
+          ls -l ui/coverage/
+          if [ ! -f ui/coverage/lcov.info ]; then
+            echo "ui/coverage/lcov.info missing"
+            exit 1
+          fi
+          head -n 50 ui/coverage/lcov.info
+          unexpected=$(grep '^SF:' ui/coverage/lcov.info | grep -v '^SF:ui/src/' || true)
+          if [ -n "$unexpected" ]; then
+            echo "lcov.info contains unexpected paths:"
+            echo "$unexpected"
+            exit 1
+          fi
       - name: Upload Codecov (UI)
         uses: codecov/codecov-action@v4
         with:


### PR DESCRIPTION
## Summary
- verify `ui/coverage/lcov.info` exists
- ensure UI coverage source files are under `ui/src`

## Testing
- `pre-commit run --files .github/workflows/ci.yml`


------
https://chatgpt.com/codex/tasks/task_b_68b828aa7750832aa22046d56d966c01