### PR TITLE
feat: configure coverage targets

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,9 +4,18 @@ codecov:
     wait_for_ci: true
 coverage:
   status:
+    # TODO: When server and Python reach ~100% coverage,
+    # raise their targets and tighten the project target to 100%.
+    flags:
+      ui:
+        target: 100%
+      server:
+        target: 0%
+      python:
+        target: 0%
     project:
       default:
-        target: auto
+        target: 5%
         threshold: 0%
     patch:
       default:


### PR DESCRIPTION
## Summary
- add per-flag coverage targets and placeholder project goal to Codecov config
- document future tightening of coverage targets

## Testing
- `pytest` *(fails: KeyboardInterrupt after 9 passed; see log)*


------
https://chatgpt.com/codex/tasks/task_b_68b829f500f4832aabad6fcad451c673