### PR TITLE
docs: document Node 22 runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ pip install scipy
 > ```
 
 ## Local Development
+Use Node.js 22.x for all Node-based tooling (see `.node-version` and `.nvmrc`).
 ```bash
 pip install -r requirements.lock
 pip install -r scripts/requirements.txt  # utilities like governor.py


### PR DESCRIPTION
## Summary
- note Node.js 22.x as required runtime in README

## Testing
- `pytest -q`
- `cd ui && npm test`
- `cd server && npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_b_68b87382ba80832ab47b2b069db07af5