### PR TITLE
chore(ci,npm): remove proxy settings & sanitize env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,14 @@ jobs:
     container: node:22-bullseye
     steps:
       - uses: actions/checkout@v5
+      - name: Sanitize proxy env (global)
+        shell: bash
+        run: |
+          unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY npm_config_proxy npm_config_http_proxy npm_config_https_proxy
+          npm config delete proxy || true
+          npm config delete http-proxy || true
+          npm config delete https-proxy || true
+          echo "Global proxy config removed"
       - uses: actions/cache@v4
         with:
           path: ~/.npm
@@ -19,6 +27,10 @@ jobs:
           path: ui/node_modules/.vite
           key: ${{ runner.os }}-vite-${{ hashFiles('ui/package-lock.json') }}
           restore-keys: ${{ runner.os }}-vite-
+      - name: Sanitize proxy env
+        run: |
+          unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY npm_config_proxy npm_config_http_proxy npm_config_https_proxy
+          echo "Proxy env sanitized"
       - run: npm ci
         working-directory: ui
       - run: npm run lint --if-present
@@ -46,11 +58,23 @@ jobs:
     defaults: { run: { working-directory: server } }
     steps:
       - uses: actions/checkout@v5
+      - name: Sanitize proxy env (global)
+        shell: bash
+        run: |
+          unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY npm_config_proxy npm_config_http_proxy npm_config_https_proxy
+          npm config delete proxy || true
+          npm config delete http-proxy || true
+          npm config delete https-proxy || true
+          echo "Global proxy config removed"
       - uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-server-npm-${{ hashFiles('server/package-lock.json') }}
           restore-keys: ${{ runner.os }}-server-npm-
+      - name: Sanitize proxy env
+        run: |
+          unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY npm_config_proxy npm_config_http_proxy npm_config_https_proxy
+          echo "Proxy env sanitized"
       - run: npm ci
       - run: npm run lint --if-present
       - run: npm run build --if-present
@@ -66,6 +90,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+      - name: Sanitize proxy env (global)
+        shell: bash
+        run: |
+          unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY npm_config_proxy npm_config_http_proxy npm_config_https_proxy
+          npm config delete proxy || true
+          npm config delete http-proxy || true
+          npm config delete https-proxy || true
+          echo "Global proxy config removed"
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
@@ -74,6 +106,10 @@ jobs:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt', 'requirements-dev.txt') }}
           restore-keys: ${{ runner.os }}-pip-
+      - name: Sanitize proxy env
+        run: |
+          unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY npm_config_proxy npm_config_http_proxy npm_config_https_proxy
+          echo "Proxy env sanitized"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,3 +33,13 @@ repos:
       - id: prettier
         files: ^ui/
         exclude: ^ui/node_modules/
+
+# Block accidental proxy config lines in tracked files
+  - repo: local
+    hooks:
+      - id: block-proxy-lines
+        name: Block proxy config lines
+        entry: |
+          bash -lc "if git grep -InE '(^|\s)(proxy|http-proxy|https-proxy)\s*=' -- . :!**/node_modules/** :!**/.git/**; then echo 'ERROR: Proxy config detected in tracked files. Remove it.'; exit 1; fi"
+        language: system
+        files: '.*'

--- a/docs/NO_PROXY.md
+++ b/docs/NO_PROXY.md
@@ -1,0 +1,12 @@
+# No Proxy Configuration in This Repository
+
+This project must not set proxy configuration in `.npmrc` or environment variables.
+If you need a proxy for your network, configure it **outside** of this repo (e.g., your shell profile)
+and never commit proxy settings here.
+
+### Disallowed in repo
+- `.npmrc` keys: `proxy`, `http-proxy`, `https-proxy`
+- ENV vars in CI or checked-in files: `http_proxy`, `https_proxy`, `HTTP_PROXY`, `HTTPS_PROXY`, `npm_config_*proxy*`
+
+### CI behavior
+CI unsets all proxy-related env vars before any `npm` step.

--- a/ui/package.json
+++ b/ui/package.json
@@ -8,6 +8,7 @@
   },
   "engineStrict": true,
   "scripts": {
+    "preinstall": "node -e \"['http_proxy','https_proxy','HTTP_PROXY','HTTPS_PROXY','npm_config_proxy','npm_config_http_proxy','npm_config_https_proxy'].forEach(k=>{if(process.env[k]){delete process.env[k]}})\"",
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",


### PR DESCRIPTION
## Summary
- document that repository forbids proxy settings
- sanitize proxy-related env vars in CI
- prevent proxy configs via preinstall script and pre-commit hook

## Testing
- `npm config list`
- `pre-commit run block-proxy-lines --files .github/workflows/ci.yml docs/NO_PROXY.md ui/package.json .pre-commit-config.yaml`
- `npm test --prefix ui` *(partial, cancelled)*
- `pytest -m "not slow" --maxfail=1 -q`


------
https://chatgpt.com/codex/tasks/task_b_68b879743d80832a9f0591902ce39f02