### PR TITLE
Ensure CI installs gateway requirements for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,12 +72,12 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt', 'requirements-dev.txt') }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt', 'requirements-dev.txt', 'src/gateway/requirements.txt') }}
           restore-keys: ${{ runner.os }}-pip-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt -r requirements-dev.txt
+          pip install -r requirements.txt -r requirements-dev.txt -r src/gateway/requirements.txt
       - name: Run tests
         run: |
           pytest -m "not slow" --maxfail=1 -q --durations=10 --cov=src --cov-report=xml


### PR DESCRIPTION
## Summary
- install FastAPI gateway dependencies during CI
- include gateway requirements in pip cache key

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `pytest -m "not slow"`


------
https://chatgpt.com/codex/tasks/task_b_68b87cc31294832a9f4df879cb1c6a15