### PR TITLE
docs: mention npm ci for node packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ pip install scipy
 
 ## Local Development
 Use Node.js 22.x for all Node-based tooling (see `.node-version` and `.nvmrc`).
+Install Node dependencies with `npm ci` for reproducible builds in the `server` and `ui` packages.
 ```bash
 pip install -r requirements.lock
 pip install -r scripts/requirements.txt  # utilities like governor.py


### PR DESCRIPTION
## Summary
- document using `npm ci` for reproducible `ui` and `server` installs

## Testing
- `pre-commit run --files README.md`
- `npm ci` (server)
- `npm run test:ci` (server)
- `npm ci` (ui)
- `npm run test:ci` (ui)


------
https://chatgpt.com/codex/tasks/task_b_68b88bda8970832aa02f8b3d82b7747e