### PR TITLE
build(ci): fix ESLint 9 peer deps by upgrading react-hooks plugin and scoping installs to ui

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
     rev: v9.32.0
     hooks:
       - id: eslint
-        args: [--fix]
+        args: [--fix, --resolve-plugins-relative-to, ui]
         files: ^ui/
         types_or: [javascript, jsx, ts, tsx]
         exclude: ^ui/node_modules/

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -26,7 +26,7 @@
         "@vitest/coverage-v8": "^2.1.9",
         "eslint": "^9.34.0",
         "eslint-plugin-react": "^7.37.5",
-        "eslint-plugin-react-hooks": "^5.0.0",
+        "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.20",
         "jsdom": "^24.1.0",
         "msw": "^2.11.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -27,7 +27,7 @@
     "@vitest/coverage-v8": "^2.1.9",
     "eslint": "^9.34.0",
     "eslint-plugin-react": "^7.37.5",
-    "eslint-plugin-react-hooks": "^5.0.0",
+    "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
     "jsdom": "^24.1.0",
     "msw": "^2.11.1",


### PR DESCRIPTION
## Summary
- upgrade eslint-plugin-react-hooks to 5.2.0 in ui
- resolve ESLint plugins relative to ui in pre-commit config

## Testing
- `pre-commit run --files .pre-commit-config.yaml ui/package.json ui/package-lock.json`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68b88d220f18832abeab839a975a63a5