### PR TITLE
chore: add asyncio pytest marker

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 markers =
     slow: marks tests as slow (deselect with '-m "not slow"')
+    asyncio: mark tests that use asyncio


### PR DESCRIPTION
## Summary
- register asyncio marker in pytest configuration

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b8fd9a16dc832ab9e315fc349a59c6