### PR TITLE
Configure coverage in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[tool.coverage.run]
+source = ["src"]
+omit = [
+    "src/**/__init__.py",
+    "src/**/config.py",
+    "src/**/settings.py",
+    "src/**/celery.py",
+]
+
+[tool.coverage.report]
+fail_under = 100
+show_missing = true
+exclude_lines = [
+    "pragma: no cover",
+    "def __repr__",
+    "if self\\.debug",
+    "if settings\\.DEBUG",
+    "raise AssertionError",
+    "raise NotImplementedError",
+    "if 0:",
+    "if __name__ == \"__main__\":",
+]


### PR DESCRIPTION
## Summary
- Add pyproject coverage configuration using src directory as source.
- Require full coverage and hide boilerplate files from measurement.

## Testing
- `pre-commit run --files pyproject.toml`
- `pytest` *(partial run: 9 passed, interrupted due to time)*

------
https://chatgpt.com/codex/tasks/task_b_68b9168653f8832a9af15a5788cd949c