### PR TITLE
test: add gateway error handling test

### DIFF
--- a/tests/test_gateway_errors.py
+++ b/tests/test_gateway_errors.py
@@ -1,0 +1,28 @@
+import httpx
+from fastapi.testclient import TestClient
+
+from src.gateway.main import app
+
+
+def test_orchestrate_unreachable(monkeypatch):
+    """Return an error when orchestrator call fails."""
+
+    class DummyAsyncClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+        async def post(self, url, json):
+            raise httpx.RequestError("boom", request=httpx.Request("POST", url))
+
+    monkeypatch.setattr(httpx, "AsyncClient", DummyAsyncClient)
+    client = TestClient(app)
+    resp = client.post("/orchestrate", json={"task": "demo"})
+    assert resp.status_code in (500, 502)
+    assert "error" in resp.json()
+


### PR DESCRIPTION
## Summary
- add test ensuring gateway returns error when orchestrator call fails

## Testing
- `pytest tests/test_gateway_errors.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68b918a5cb04832a856a4e1626a9c489