### PR TITLE
feat: allow custom nltk packages

### DIFF
--- a/src/orchestrator/orchestrator.py
+++ b/src/orchestrator/orchestrator.py
@@ -5,6 +5,7 @@ import os
 import subprocess
 import tempfile
 import types
+from collections.abc import Mapping
 
 from langgraph import Graph
 
@@ -42,14 +43,17 @@ def ensure_nltk_real() -> bool:
     return True
 
 
-def ensure_nltk_data() -> types.ModuleType:
+def ensure_nltk_data(
+    packages: Mapping[str, str] | None = None,
+) -> types.ModuleType:
     """Ensure required NLTK corpora are available and return the nltk module."""
 
     ensure_nltk_real()
-    packages = {
-        "punkt": "tokenizers/punkt",
-        "averaged_perceptron_tagger": "taggers/averaged_perceptron_tagger",
-    }
+    if packages is None:
+        packages = {
+            "punkt": "tokenizers/punkt",
+            "averaged_perceptron_tagger": "taggers/averaged_perceptron_tagger",
+        }
     missing = []
     for pkg, path in packages.items():
         try:


### PR DESCRIPTION
## Summary
- allow orchestrator's ensure_nltk_data to accept custom NLTK packages
- add regression test for ensuring custom package handling

## Testing
- `pytest` *(fails: KeyboardInterrupt after some tests)*

------
https://chatgpt.com/codex/tasks/task_b_68b9325228e4832ab513f5e1fb57596d