### PR TITLE
Add comprehensive tests to reach full coverage

### DIFF
--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,9 +1,12 @@
 import math
+import runpy
+import sys
 
 import pytest
 
-from src.examples.sympy_demo import solve_quadratic
+from src.examples import scipy_demo, sympy_demo
 from src.examples.scipy_demo import integrate_sin
+from src.examples.sympy_demo import solve_quadratic
 
 
 def test_sympy_demo():
@@ -13,3 +16,31 @@ def test_sympy_demo():
 def test_scipy_demo():
     result = integrate_sin()
     assert result == pytest.approx(2.0, abs=1e-6)
+
+
+def test_sympy_demo_main(monkeypatch, capsys):
+    monkeypatch.setattr(sys, "argv", ["prog", "1", "0", "-4"])
+    sympy_demo.main()
+    out = capsys.readouterr().out
+    assert "-2" in out and "2" in out
+
+
+def test_scipy_demo_main(monkeypatch, capsys):
+    monkeypatch.setattr(sys, "argv", ["prog", "0", str(math.pi)])
+    scipy_demo.main()
+    out = capsys.readouterr().out.strip()
+    assert float(out) == pytest.approx(2.0, abs=1e-6)
+
+
+def test_sympy_demo_run_module(monkeypatch, capsys):
+    monkeypatch.setattr(sys, "argv", ["prog", "1", "0", "-4"])
+    runpy.run_module("src.examples.sympy_demo", run_name="__main__")
+    out = capsys.readouterr().out
+    assert "-2" in out and "2" in out
+
+
+def test_scipy_demo_run_module(monkeypatch, capsys):
+    monkeypatch.setattr(sys, "argv", ["prog", "0", str(math.pi)])
+    runpy.run_module("src.examples.scipy_demo", run_name="__main__")
+    out = capsys.readouterr().out.strip()
+    assert float(out) == pytest.approx(2.0, abs=1e-6)

--- a/tests/test_gateway_streams.py
+++ b/tests/test_gateway_streams.py
@@ -1,0 +1,67 @@
+import asyncio
+
+from starlette.websockets import WebSocketDisconnect
+
+from src.gateway import main as gw
+
+
+def test_kpi_metrics_single_latency():
+    gw.REQUEST_LATENCIES[:] = [100.0]
+    gw.REQUEST_COUNT = 1
+    kpis = gw._kpi_metrics()
+    assert kpis.latency_p95_ms == 100.0
+
+
+def test_telemetry_event():
+    gw.REQUEST_LATENCIES[:] = []
+    gw.REQUEST_COUNT = 0
+    event = gw._telemetry_event()
+    assert event.system.cpu_percent >= 0
+
+
+def test_websocket_endpoint_iteration(monkeypatch):
+    gw.REQUEST_LATENCIES[:] = []
+    gw.REQUEST_COUNT = 0
+
+    events = []
+
+    class DummyWebSocket:
+        async def accept(self):
+            pass
+
+        async def send_json(self, data):
+            events.append(data)
+            if len(events) >= 2:
+                raise WebSocketDisconnect()
+
+        async def close(self):
+            pass
+
+    async def fast_sleep(_):
+        return None
+
+    monkeypatch.setattr(asyncio, "sleep", fast_sleep)
+
+    async def run():
+        await gw.websocket_endpoint(DummyWebSocket())
+
+    asyncio.run(run())
+    assert len(events) == 2
+
+
+def test_sse_event_generator(monkeypatch):
+    async def fast_sleep(_):
+        return None
+
+    monkeypatch.setattr(asyncio, "sleep", fast_sleep)
+
+    async def run():
+        resp = await gw.sse_endpoint()
+        gen = resp.body_iterator
+        first = await gen.__anext__()
+        assert first.startswith("data: ")
+        second = await gen.__anext__()
+        assert second.startswith("data: ")
+        await gen.aclose()
+
+    asyncio.run(run())

--- a/tests/test_math_agent.py
+++ b/tests/test_math_agent.py
@@ -1,7 +1,9 @@
 import builtins
+
 import pytest
 
-from src.orchestrator.math_agent import app as math_app, parse_math_query
+from src.orchestrator.math_agent import app as math_app
+from src.orchestrator.math_agent import parse_math_query
 
 
 def test_parse_integrate_symbolic():
@@ -56,3 +58,8 @@ def test_malicious_expression_rejected():
 def test_invalid_integral_bound():
     with pytest.raises(ValueError):
         parse_math_query("integrate x from 0 to y")
+
+
+def test_parse_simplify():
+    result = parse_math_query("simplify sin(x)**2 + cos(x)**2")
+    assert str(result) == "1"

--- a/tests/test_orchestrator_main_extra.py
+++ b/tests/test_orchestrator_main_extra.py
@@ -1,0 +1,102 @@
+import importlib
+import sys
+import types
+
+import pytest
+from fastapi import HTTPException
+
+
+@pytest.fixture
+def om(monkeypatch):
+    class DummyGraph:
+        def add_node(self, *a, **k):
+            return None
+
+        def add_edge(self, *a, **k):
+            return None
+
+        def add_conditional_edge(self, *a, **k):
+            return None
+
+        def compile(self):
+            return None
+
+    monkeypatch.setitem(
+        sys.modules, "langgraph", types.SimpleNamespace(Graph=DummyGraph)
+    )
+    module = importlib.reload(importlib.import_module("src.orchestrator.main"))
+    module.workflow_app = types.SimpleNamespace(invoke=lambda state: state)
+    return module
+
+
+def test_thermal_guard_no_trigger(om, monkeypatch):
+    class DummyPsutil:
+        @staticmethod
+        def sensors_temperatures():
+            return {"cpu": [types.SimpleNamespace(current=30)]}
+
+    monkeypatch.setenv("THERMAL_GUARD_MAX_C", "60")
+    monkeypatch.setitem(sys.modules, "psutil", DummyPsutil)
+    assert om.thermal_guard() is False
+
+
+def test_oom_guard_disabled(om, monkeypatch):
+    monkeypatch.delenv("OOM_GUARD_MIN_AVAILABLE_MB", raising=False)
+    assert om.oom_guard() is False
+
+
+def test_oom_guard_sufficient_memory(om, monkeypatch):
+    class DummyPsutil:
+        @staticmethod
+        def virtual_memory():
+            return types.SimpleNamespace(available=200 * 1024 * 1024)
+
+    monkeypatch.setenv("OOM_GUARD_MIN_AVAILABLE_MB", "100")
+    monkeypatch.setitem(sys.modules, "psutil", DummyPsutil)
+    assert om.oom_guard() is False
+
+
+def test_route_model_auto_no_endpoints(om, monkeypatch):
+    monkeypatch.delenv("SLM_BASE_URL", raising=False)
+    monkeypatch.delenv("NIM_BASE_URL", raising=False)
+    monkeypatch.delenv("VLLM_BASE_URL", raising=False)
+    with pytest.raises(HTTPException):
+        om._route_model(None)
+
+
+def test_route_model_explicit(om, monkeypatch):
+    monkeypatch.setenv("NIM_BASE_URL", "http://nim")
+    assert om._route_model("nim") == "http://nim"
+
+
+def test_run_memory_error(om, monkeypatch):
+    monkeypatch.setattr(om, "_route_model", lambda policy: "url")
+    called = {}
+    monkeypatch.setattr(om, "oom_guard", lambda: called.setdefault("x", True))
+
+    def raise_mem(state):
+        raise MemoryError
+
+    monkeypatch.setattr(om.workflow_app, "invoke", raise_mem)
+    with pytest.raises(HTTPException) as exc:
+        om.run(om.TaskRequest(input="x"))
+    assert exc.value.status_code == 500
+    assert called["x"]
+
+
+def test_run_generic_error(om, monkeypatch):
+    monkeypatch.setattr(om, "_route_model", lambda policy: "url")
+    monkeypatch.setattr(
+        om.workflow_app,
+        "invoke",
+        lambda state: (_ for _ in ()).throw(ValueError("boom")),
+    )
+    with pytest.raises(HTTPException) as exc:
+        om.run(om.TaskRequest(input="x"))
+    assert exc.value.status_code == 500
+
+
+def test_math_endpoint(om, monkeypatch):
+    monkeypatch.setattr(om.math_app, "invoke", lambda state: {"result": 1})
+    resp = om.math(om.MathRequest(query="1+1"))
+    assert resp.result["result"] == 1

--- a/tests/test_orchestrator_utils.py
+++ b/tests/test_orchestrator_utils.py
@@ -1,0 +1,106 @@
+import importlib
+import sys
+import types
+
+import pytest
+
+
+def _setup_langgraph(monkeypatch):
+    class DummyGraph:
+        def add_node(self, *a, **k):
+            return None
+
+        def add_edge(self, *a, **k):
+            return None
+
+        def add_conditional_edge(self, *a, **k):
+            return None
+
+        def compile(self):
+            return None
+
+    monkeypatch.setitem(
+        sys.modules, "langgraph", types.SimpleNamespace(Graph=DummyGraph)
+    )
+
+
+def _setup_nltk(monkeypatch):
+    fake = types.SimpleNamespace()
+    fake.data = types.SimpleNamespace(find=lambda path: True)
+    fake.sent_tokenize = lambda text: [s for s in text.split(".") if s]
+    fake.word_tokenize = lambda text: text.split()
+    fake.pos_tag = lambda tokens: [(t, "VB") for t in tokens]
+    monkeypatch.setitem(sys.modules, "nltk", fake)
+    return fake
+
+
+def _load_orch(monkeypatch):
+    _setup_langgraph(monkeypatch)
+    _setup_nltk(monkeypatch)
+    return importlib.reload(importlib.import_module("src.orchestrator.orchestrator"))
+
+
+def test_nltk_shim_download(monkeypatch):
+    _setup_langgraph(monkeypatch)
+    orch = importlib.reload(importlib.import_module("src.orchestrator.orchestrator"))
+    assert orch._NLTKShim.download("punkt") is None
+
+
+def test_build_plan_and_planner(monkeypatch):
+    orch = _load_orch(monkeypatch)
+    plan = orch._build_plan("Hello world.")
+    assert plan.startswith("-")
+    res = orch.planner_fn({"input": "Hello world."})
+    assert "plan" in res and res["context_size"] == len("Hello world.")
+
+
+def test_implement_and_entropy(monkeypatch):
+    orch = _load_orch(monkeypatch)
+    result = orch.implement_fn({"plan": "- do things"})
+    assert "def do_things" in result["code"]
+    assert orch._shannon_entropy("") == 0.0
+
+
+def test_implement_missing_corpus(monkeypatch):
+    orch = _load_orch(monkeypatch)
+    monkeypatch.setattr(
+        orch, "ensure_nltk_data", lambda: (_ for _ in ()).throw(LookupError("missing"))
+    )
+    with pytest.raises(RuntimeError):
+        orch.implement_fn({"plan": "- step"})
+
+
+def test_verify_fn_errors(monkeypatch):
+    orch = _load_orch(monkeypatch)
+    monkeypatch.setitem(
+        sys.modules,
+        "py_compile",
+        types.SimpleNamespace(
+            compile=lambda *a, **k: (_ for _ in ()).throw(Exception())
+        ),
+    )
+
+    class DummyResult:
+        stdout = "E1\nE2\n"
+
+    monkeypatch.setattr(orch.subprocess, "run", lambda *a, **k: DummyResult())
+    res = orch.verify_fn({"code": "bad"})
+    assert res["passed"] is False
+    assert res["lint_delta"] == 1 / (1 + 2)
+
+
+def test_refine_fn_success(monkeypatch):
+    orch = _load_orch(monkeypatch)
+    monkeypatch.setattr(orch.subprocess, "run", lambda *a, **k: None)
+    res = orch.refine_fn({"code": "x=1"})
+    assert "x=1" in res["code"]
+
+
+def test_human_review_and_conditions(monkeypatch):
+    orch = _load_orch(monkeypatch)
+    res = orch.human_review_fn({"plan": "run tests"})
+    assert res["approved"]
+    assert orch.approve_cond(res)
+    assert orch.refine_gate(
+        {"passed_delta": 0, "lint_delta": 0, "entropy_delta": 0, "budget": 1.0}
+    )


### PR DESCRIPTION
## Summary
- add script-style tests for examples modules
- exercise gateway telemetry and streaming endpoints
- cover orchestrator utilities, guards and error branches
- expand rag tests for connection pooling and failure cases
- verify math agent simplify command

## Testing
- `coverage run -m pytest -m "not slow" -q`
- `pre-commit run --files tests/test_examples.py tests/test_math_agent.py tests/test_gateway_streams.py tests/test_orchestrator_main_extra.py tests/test_orchestrator_utils.py tests/test_rag.py`


------
https://chatgpt.com/codex/tasks/task_b_68b94293b7b4832aa4cc8ceb958f5dda