### PR TITLE
test: add parse_math_query error test

### DIFF
--- a/tests/test_math_agent_errors.py
+++ b/tests/test_math_agent_errors.py
@@ -1,0 +1,8 @@
+import pytest
+
+from src.orchestrator.math_agent import parse_math_query
+
+
+def test_parse_math_query_error() -> None:
+    with pytest.raises(Exception):
+        parse_math_query("this is not a math expression")


### PR DESCRIPTION
## Summary
- test invalid math queries raise exceptions

## Testing
- `pre-commit run --files tests/test_math_agent_errors.py`
- `pytest tests/test_math_agent_errors.py`


------
https://chatgpt.com/codex/tasks/task_b_68b95878ba20832a9ede41f7df369b99