### PR TITLE
Exclude install script main from coverage

### DIFF
--- a/scripts/install_nltk_data.py
+++ b/scripts/install_nltk_data.py
@@ -9,5 +9,5 @@ def main() -> None:
     nltk.download("averaged_perceptron_tagger")
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     main()


### PR DESCRIPTION
## Summary
- ensure install_nltk_data.py main block is excluded from coverage

## Testing
- `pytest --cov` *(partial run: aborted after ~14 min, 13 tests passed)*
- `pytest --cov --cov-fail-under=0 tests/test_examples.py::test_sympy_demo_run_module -q`


------
https://chatgpt.com/codex/tasks/task_b_68b97321b850832aae1a8033fe3f09f6