### PR TITLE
chore: exclude SciPy demo entry point from coverage

### DIFF
--- a/src/examples/scipy_demo.py
+++ b/src/examples/scipy_demo.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import argparse
 import math
+
 from scipy import integrate
 
 
@@ -25,5 +26,5 @@ def main():
     print(integrate_sin(args.a, args.b))
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     main()


### PR DESCRIPTION
## Summary
- ignore `scipy_demo` CLI entry point in coverage metrics

## Testing
- `pre-commit run --files src/examples/scipy_demo.py`
- `pytest --cov` *(fails: KeyboardInterrupt after 13 tests)*
- `coverage run src/examples/scipy_demo.py && coverage report src/examples/scipy_demo.py`


------
https://chatgpt.com/codex/tasks/task_b_68b97853fad0832a8b8d51609aff65ee