### PR TITLE
chore: exclude sympy demo entry point from coverage

### DIFF
--- a/src/examples/sympy_demo.py
+++ b/src/examples/sympy_demo.py
@@ -27,5 +27,5 @@ def main():
     print(roots)
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     main()


### PR DESCRIPTION
## Summary
- exclude sympy demo entry point from coverage

## Testing
- `pytest --cov` *(fails: KeyboardInterrupt after 13 passed)*

------
https://chatgpt.com/codex/tasks/task_b_68b98e113ca0832abee71d7369fec0fe