### PR TITLE
chore: tighten Codecov coverage gates

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -9,29 +9,19 @@ coverage:
     # increase each toward 100% and raise the project target accordingly.
     flags:
       ui:
-        target: 100%
-      server:
-        target: 60%
+        target: 100
+        threshold: 0
       python:
-        target: 60%
-    project:
-      default:
-        target: 5%
-        threshold: 0%
-    patch:
-      default:
-        target: 100%
-        threshold: 0%
+        target: 100
+        threshold: 0
+    project: off
+    patch: off
 
 flags:
   ui:
     carryforward: false
     paths:
       - ui/src
-  server:
-    carryforward: false
-    paths:
-      - server/api
   python:
     carryforward: false
     paths:


### PR DESCRIPTION
## Summary
- require full coverage for UI and Python flags
- disable project and patch coverage gates
- drop server flag from Codecov configuration

## Testing
- `pytest -q` *(fails: KeyboardInterrupt, 13 passed, 2 warnings)*

------
https://chatgpt.com/codex/tasks/task_b_68b9993a7cf0832a9ddceb7c2c952f41