### PR TITLE
test: configure vitest coverage

### DIFF
--- a/ui/vitest.config.mjs
+++ b/ui/vitest.config.mjs
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vitest/config';
+import { defineConfig, configDefaults, coverageConfigDefaults } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
@@ -7,10 +7,18 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: ['./src/setupTests.ts'],
+    exclude: [...configDefaults.exclude, 'src/main.jsx', 'src/**/__tests__/**'],
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'lcov', 'html'],
+      all: true,
+      include: ['src/**/*.{js,jsx,ts,tsx}'],
+      exclude: [...coverageConfigDefaults.exclude, 'src/main.jsx', 'src/**/__tests__/**'],
+      reporter: ['text', 'html', 'lcov'],
       reportsDirectory: './coverage',
+      lines: 100,
+      functions: 100,
+      statements: 100,
+      branches: 100,
     },
   },
 });


### PR DESCRIPTION
## Summary
- exclude main entry and internal tests from vitest
- enforce full coverage requirements with v8 coverage provider

## Testing
- `cd ui && npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_b_68b99b0ed714832ab3f7ecca305761eb