### PR TITLE
docs(roadmap): expand roadmap with 2025 innovations

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,55 @@
+# Naestro Roadmap
+
+## 0. Mission
+Our mission is to bring reasoning and generative intelligence into every creative workflow. 2025 is about turning Naestro from a research project into a stable platform with crisp APIs and predictable performance.
+
+## 1. Core Architecture
+Establish modular runtime and typed contracts across subsystems; finish shift to Graphiti.
+
+## 2. Language Capabilities
+Release multi-lingual semantic layer; integrate symbolics with neural models.
+
+## 3. Data & Knowledge
+Automate ingestion, labeling, and governance of knowledge artifacts; deliver reproducible datasets.
+
+## 4. Tooling
+Ship CLI and Studio improvements; enable one-command deployments.
+
+## 5. Extensibility
+Add plugin system, custom operator DSL, and public extension registry.
+
+## 6. Security & Privacy
+Implement end-to-end encryption, secure enclaves, and granular permissions.
+
+## 7. Collaboration
+Real-time shared canvases and presence indicators across clients.
+
+## 8. Performance
+GPU pipeline for inference, streaming execution, and cost dashboards.
+
+## 9. Observability
+Tracing, metrics, and event replay for every workflow.
+
+## 10. Edge & Mobile
+Lightweight runtime for on-device tasks and offline operation.
+
+## 11. Community
+Launch education portal, host design challenges, and expand governance council.
+
+## 12. Research
+Explore long-horizon reasoning, hybrid search, and emergent agent behavior.
+
+### Configuration Flags
+| Flag | Description | Default |
+| --- | --- | --- |
+| `NAESTRO_EXPERIMENTAL` | Enable experimental features | `false` |
+| `NAESTRO_GPU` | Force GPU execution | `auto` |
+| `NAESTRO_TELEMETRY` | Opt in to anonymous metrics | `true` |
+| `NAESTRO_SANDBOX` | Use sandboxed runtime | `true` |
+
+### Milestones
+- [ ] 2025-Q1: Architectural consolidation and typed APIs.
+- [ ] 2025-Q2: Public plugin registry and data governance tooling.
+- [ ] 2025-Q3: Edge runtime beta and observability dashboard.
+- [ ] 2025-Q4: Naestro 1.0 launch with community festival.
+


### PR DESCRIPTION
## Summary
- add comprehensive roadmap sections 0-12
- document configuration flags and 2025 milestones

## Testing
- `pre-commit run --files ROADMAP.md`
- `pytest` *(partially executed: 13 passed before KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_b_68ba4d5244c8832abb0e24d519101282