### PR TITLE
test: add renderWithProviders example

### DIFF
--- a/ui/src/test-utils.test.tsx
+++ b/ui/src/test-utils.test.tsx
@@ -1,0 +1,23 @@
+import { renderWithProviders, screen, waitFor } from './test-utils';
+import { useEffect, useState } from 'react';
+import { describe, it, expect } from 'vitest';
+
+function AsyncComponent() {
+  const [text, setText] = useState('loading');
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setText('loaded');
+    }, 0);
+    return () => clearTimeout(timer);
+  }, []);
+  return <div>{text}</div>;
+}
+
+describe('renderWithProviders', () => {
+  it('renders and waits for async content', async () => {
+    renderWithProviders(<AsyncComponent />);
+    await waitFor(() => {
+      expect(screen.getByText('loaded')).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add test for renderWithProviders that uses screen and waitFor

## Testing
- `pnpm -w test:ci` *(fails: --workspace-root may only be used inside a workspace)*
- `pnpm -C ui test:ci`


------
https://chatgpt.com/codex/tasks/task_b_68bb85891564832aa65b693a1445899b