### PR TITLE
chore: use SWC React plugin for Vite and include SVG assets

### DIFF
--- a/ui/vite.config.js
+++ b/ui/vite.config.js
@@ -1,8 +1,9 @@
 import { defineConfig } from "vite";
-import react from "@vitejs/plugin-react";
+import react from "@vitejs/plugin-react-swc";
 
 export default defineConfig({
   plugins: [react()],
+  assetsInclude: ["**/*.svg"],
   server: {
     host: true,
     port: 5173,


### PR DESCRIPTION
## Summary
- use `@vitejs/plugin-react-swc` in Vite config
- add `assetsInclude` to handle SVG assets

## Testing
- `pnpm -w build` *(fails: --workspace-root may only be used inside a workspace)*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_b_68bb8acc6eec832ab968ebaa8778d458