### PR TITLE
feat(ui): configure vitest globals and jest-dom alias

### DIFF
--- a/ui/vitest.config.mjs
+++ b/ui/vitest.config.mjs
@@ -3,7 +3,13 @@ import react from '@vitejs/plugin-react-swc';
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@testing-library/jest-dom$': '@testing-library/jest-dom/vitest',
+    },
+  },
   test: {
+    globals: true,
     environment: 'jsdom',
     setupFiles: ['./src/setupTests.ts'],
     css: true,


### PR DESCRIPTION
## Summary
- ensure vitest uses `@testing-library/jest-dom/vitest`
- enable Vitest globals so `expect` is available without import

## Testing
- `pnpm -w install` *(fails: --workspace-root may only be used inside a workspace)*
- `pnpm -w test:ci` *(fails: --workspace-root may only be used inside a workspace)*
- `pnpm test:ci`


------
https://chatgpt.com/codex/tasks/task_b_68bb8dc538c8832abd1da7d6461d64fb