### PR TITLE
fix vitest jest-dom alias

### DIFF
--- a/ui/src/setupTests.ts
+++ b/ui/src/setupTests.ts
@@ -1,4 +1,4 @@
-import '@testing-library/jest-dom/vitest';
+import '@testing-library/jest-dom';
 import { server } from './mocks/server';
 
 const originalError = console.error;

--- a/ui/vitest.config.mjs
+++ b/ui/vitest.config.mjs
@@ -5,7 +5,7 @@ export default defineConfig({
   plugins: [react()],
   resolve: {
     alias: {
-      '@testing-library/jest-dom$': '@testing-library/jest-dom/vitest',
+      '@testing-library/jest-dom': '@testing-library/jest-dom/vitest',
     },
   },
   test: {


### PR DESCRIPTION
## Summary
- rewrite @testing-library/jest-dom alias to cover bare imports
- import jest-dom through bare module in tests

## Testing
- `pnpm install`
- `pnpm test:ci` *(fails: Cannot find module './DialogActions')*


------
https://chatgpt.com/codex/tasks/task_b_68bb8f32c560832a9fd02de0558049ab