### PR TITLE
chore(ui): alias jest-dom for vitest

### DIFF
--- a/ui/vitest.config.mjs
+++ b/ui/vitest.config.mjs
@@ -3,6 +3,11 @@ import react from '@vitejs/plugin-react-swc';
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: [
+      { find: /^@testing-library\/jest-dom$/, replacement: '@testing-library/jest-dom/vitest' },
+    ],
+  },
   test: {
     globals: true,
     environment: 'jsdom',


### PR DESCRIPTION
## Summary
- alias `@testing-library/jest-dom` to `@testing-library/jest-dom/vitest` in Vitest config

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68bb9bccb860832ab3b3fcb4804736e4