### PR TITLE
chore: relax commitlint rules for dependabot

### DIFF
--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -4,6 +4,7 @@
  */
 module.exports = {
   extends: ['@commitlint/config-conventional'],
+  ignores: [(msg) => msg.includes('dependabot[bot]')],
   rules: {
     'type-enum': [
       2,
@@ -22,6 +23,7 @@ module.exports = {
         'revert'
       ]
     ],
-    'subject-case': [2, 'never', ['sentence-case', 'start-case', 'pascal-case', 'upper-case']]
+    'subject-case': [2, 'never', ['sentence-case', 'start-case', 'pascal-case', 'upper-case']],
+    'body-max-line-length': [2, 'always', 0]
   }
 };


### PR DESCRIPTION
## Summary
- ignore dependabot commits in commitlint
- allow long commit body lines

## Testing
- `pre-commit run --files commitlint.config.cjs`

------
https://chatgpt.com/codex/tasks/task_b_68bbac01f8f8832abd7025f1b9121211