### PR TITLE
feat: add firecrawl integration

### DIFF
--- a/integrations/firecrawl/mcp/servers/firecrawl.ts
+++ b/integrations/firecrawl/mcp/servers/firecrawl.ts
@@ -1,0 +1,12 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio";
+import { firecrawl, FirecrawlSchema } from "../../tools/firecrawl";
+
+const server = new McpServer({ name: "firecrawl", version: "0.1.0" });
+
+server.tool("crawl", FirecrawlSchema.shape, async (args) => {
+  return await firecrawl(args);
+});
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/integrations/firecrawl/n8n-nodes/Firecrawl/index.ts
+++ b/integrations/firecrawl/n8n-nodes/Firecrawl/index.ts
@@ -1,0 +1,48 @@
+import type { IExecuteFunctions, INodeType, INodeTypeDescription } from 'n8n-workflow';
+import { firecrawl } from '../../tools/firecrawl';
+
+export class Firecrawl implements INodeType {
+  description: INodeTypeDescription = {
+    displayName: 'Firecrawl',
+    name: 'firecrawl',
+    group: ['transform'],
+    version: 1,
+    description: 'Interact with the Firecrawl API',
+    defaults: { name: 'Firecrawl' },
+    inputs: ['main'],
+    outputs: ['main'],
+    properties: [
+      {
+        displayName: 'Operation',
+        name: 'operation',
+        type: 'options',
+        options: [{ name: 'Crawl', value: 'crawl' }],
+        default: 'crawl',
+      },
+      {
+        displayName: 'Options',
+        name: 'options',
+        type: 'json',
+        default: '{}',
+        description: 'All Firecrawl parameters as JSON object',
+      },
+    ],
+  };
+
+  async execute(this: IExecuteFunctions) {
+    const items: Array<Record<string, any>> = [];
+    const length = this.getInputData().length;
+
+    for (let i = 0; i < length; i++) {
+      const operation = this.getNodeParameter('operation', i) as string;
+      const options = this.getNodeParameter('options', i, {}) as any;
+
+      if (operation === 'crawl') {
+        const result = await firecrawl(options);
+        items.push(...(result.items ?? []));
+      }
+    }
+
+    return [items];
+  }
+}

--- a/integrations/firecrawl/tools/firecrawl.ts
+++ b/integrations/firecrawl/tools/firecrawl.ts
@@ -1,0 +1,36 @@
+import { z } from "zod";
+
+// Schema for Firecrawl crawl options. Additional fields are passed through to the API.
+export const FirecrawlSchema = z
+  .object({
+    url: z.string().url(),
+    apiKey: z.string().optional(),
+  })
+  .passthrough();
+
+export type FirecrawlOptions = z.infer<typeof FirecrawlSchema>;
+
+/**
+ * Calls the Firecrawl crawl API.
+ * @param options Parameters for the crawl request.
+ * @returns JSON response from the Firecrawl API.
+ */
+export async function firecrawl(options: FirecrawlOptions) {
+  const { apiKey, ...body } = FirecrawlSchema.parse(options);
+
+  const res = await fetch("https://api.firecrawl.dev/v1/crawl", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(apiKey ? { "X-API-Key": apiKey } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Firecrawl request failed: ${res.status} ${text}`);
+  }
+
+  return res.json();
+}

--- a/registry/tools.json
+++ b/registry/tools.json
@@ -1,0 +1,12 @@
+{
+  "firecrawl:crawl": {
+    "description": "Crawl a webpage using the Firecrawl API",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "url": { "type": "string" }
+      },
+      "required": ["url"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add Firecrawl tool with schema and API call
- expose crawl tool via MCP server and n8n node
- register Firecrawl in tools registry

## Testing
- `npm --prefix server run test:ci`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68bc643b9cac832a8183db98cebe024a