### PR TITLE
test: add firecrawl integration tests and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,10 @@ Spec and scaffolding guidance in [VS Code Extension](docs/VS_CODE_EXTENSION.md).
 - **Secure Sandbox** — Docker-executed verification with seccomp + no-network.  
 - **PII Calibration** — Shannon entropy thresholds with a 550-item dataset.  
 - **Observability First** — OTEL traces, Prometheus metrics, Grafana dashboards.  
-- **CI/CD** — GitHub Actions with healthchecks and hooks for shadow/canary logic.  
-- **Interactive Web UI** — Vite-powered React dashboard with Monaco editor.  
-- **SymPy & SciPy Demos** — quadratic solving and sine integration.  
+- **CI/CD** — GitHub Actions with healthchecks and hooks for shadow/canary logic.
+- **Interactive Web UI** — Vite-powered React dashboard with Monaco editor.
+- **Firecrawl Web Ingestion** — crawl sites, extract headings, embed pages, and compute sitemap coverage ratios.
+- **SymPy & SciPy Demos** — quadratic solving and sine integration.
 
 See the [User Manual](docs/USER_MANUAL.md) for a complete guide.
 

--- a/docs/integrations/firecrawl.md
+++ b/docs/integrations/firecrawl.md
@@ -1,0 +1,32 @@
+# Firecrawl Integration
+
+[← Back to INTEGRATIONS](../INTEGRATIONS.md)
+
+## Usage
+The Firecrawl crawler is exposed as a tool via the registry. Register `firecrawl:crawl` and supply a target URL when invoking it. The tool definition lives in [`registry/tools.json`](../../registry/tools.json).
+
+Example invocation:
+
+```json
+{
+  "tool": "firecrawl:crawl",
+  "args": { "url": "https://example.com" }
+}
+```
+
+Studio provides a Firecrawl panel for interactive testing and exporting n8n flows; see [`studio/panels/FirecrawlPanel.tsx`](../../studio/panels/FirecrawlPanel.tsx).
+
+## Capabilities
+- Validates crawl requests and normalizes mixed-case URLs
+- Extracts page headings and stores embeddings for each document
+- Computes sitemap coverage ratios to report uncrawled pages
+- Maps domain and HTTP errors to structured responses
+
+## Policy
+Crawling respects an allow/deny list and robots.txt rules:
+
+- Allowed domains: `example.com`
+- Denied domains: `bad.com`
+- Default rate limit: 1 QPS with burst 2
+
+These defaults can be adjusted in the source.

--- a/integrations/firecrawl/__tests__/firecrawl.spec.ts
+++ b/integrations/firecrawl/__tests__/firecrawl.spec.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import * as FirecrawlTool from '../tools/firecrawl';
+import { ingestFirecrawl } from '../ingest';
+import { evaluateCoverage } from '../evaluators';
+
+const { FirecrawlSchema, firecrawl } = FirecrawlTool;
+const originalFetch = global.fetch;
+const fixturePath = path.join(__dirname, 'fixtures', 'example-site.json');
+
+// helper to load fixture items
+function loadExampleItems() {
+  const data = fs.readFileSync(fixturePath, 'utf-8');
+  return JSON.parse(data);
+}
+
+describe('Firecrawl schema validation', () => {
+  it('accepts valid options', () => {
+    const opts = { url: 'https://example.com' };
+    expect(FirecrawlSchema.parse(opts)).toMatchObject(opts);
+  });
+
+  it('rejects invalid url', () => {
+    expect(() => FirecrawlSchema.parse({ url: 'not-a-url' } as any)).toThrow();
+  });
+});
+
+describe('Firecrawl URL normalization', () => {
+  beforeEach(() => {
+    vi.spyOn(fs, 'appendFileSync').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    global.fetch = originalFetch;
+  });
+
+  it('allows mixed-case domains via normalization', async () => {
+    const fetchMock = vi
+      .fn()
+      // robots.txt request
+      .mockResolvedValueOnce({ ok: true, text: async () => '' })
+      // crawl API request
+      .mockResolvedValueOnce({ ok: true, text: async () => '{"items":[]}' });
+
+    // @ts-ignore
+    global.fetch = fetchMock;
+
+    await firecrawl({ url: 'HTTPS://EXAMPLE.COM' });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://example.com/robots.txt',
+      expect.any(Object)
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.firecrawl.dev/v1/crawl',
+      expect.objectContaining({ method: 'POST' })
+    );
+  });
+});
+
+describe('Firecrawl error mapping', () => {
+  beforeEach(() => {
+    vi.spyOn(fs, 'appendFileSync').mockImplementation(() => {});
+    (FirecrawlTool as any).robotsCache?.clear?.();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    global.fetch = originalFetch;
+  });
+
+  it('rejects denied domains', async () => {
+    await expect(firecrawl({ url: 'https://bad.com' })).rejects.toThrow(
+      /Domain denied by policy: bad.com/
+    );
+  });
+
+  it('rejects domains outside allow list', async () => {
+    await expect(firecrawl({ url: 'https://unknown.com' })).rejects.toThrow(
+      /Domain not allowed by policy: unknown.com/
+    );
+  });
+
+  it('maps HTTP errors to thrown errors', async () => {
+    const fetchMock = vi.fn((url: string) =>
+      Promise.resolve(
+        url.endsWith('/robots.txt')
+          ? { ok: true, text: async () => '' }
+          : { ok: false, status: 500, text: async () => 'boom' }
+      )
+    );
+
+    // @ts-ignore
+    global.fetch = fetchMock;
+
+    await expect(firecrawl({ url: 'https://example.com' })).rejects.toThrow(
+      /Firecrawl request failed: 500 boom/
+    );
+  });
+});
+
+describe('Firecrawl end-to-end ingest', () => {
+  it('parses headings, stores embeddings, and computes coverage', async () => {
+    const items = loadExampleItems();
+    const docs = await ingestFirecrawl(items);
+
+    // headings parsed
+    const headings = docs.map((d) => d.meta.heading);
+    expect(headings).toContain('Welcome');
+    expect(headings).toContain('Section');
+    expect(headings).toContain('About');
+
+    // embeddings stored
+    for (const d of docs) {
+      expect(Array.isArray(d.embedding)).toBe(true);
+      expect(d.embedding.length).toBeGreaterThan(0);
+    }
+
+    // coverage ratio
+    const sitemap = [
+      'https://example.com',
+      'https://example.com/about',
+      'https://example.com/missing'
+    ];
+    const { coverage, missing } = evaluateCoverage(
+      sitemap,
+      items.map((i: any) => i.url)
+    );
+    expect(coverage).toBeCloseTo(2 / 3);
+    expect(missing).toEqual(['https://example.com/missing']);
+  });
+});

--- a/integrations/firecrawl/__tests__/fixtures/example-site.json
+++ b/integrations/firecrawl/__tests__/fixtures/example-site.json
@@ -1,0 +1,12 @@
+[
+  {
+    "id": "1",
+    "url": "https://example.com",
+    "markdown": "# Welcome\nThis is the home page.\n## Section\nMore content here."
+  },
+  {
+    "id": "2",
+    "url": "https://example.com/about",
+    "markdown": "# About\nAll about this site."
+  }
+]


### PR DESCRIPTION
## Summary
- add unit and e2e tests for firecrawl integration
- document firecrawl usage, policy and studio panel
- highlight firecrawl capabilities in root README and integration docs

## Testing
- `pre-commit run --files README.md docs/integrations/firecrawl.md`


------
https://chatgpt.com/codex/tasks/task_b_68bc7a9eb754832ab488db25438a10ca