### PR TITLE
docs: add Firecrawl Web Ingestion feature bullet

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,10 @@ Spec and scaffolding guidance in [VS Code Extension](docs/VS_CODE_EXTENSION.md).
 - **Secure Sandbox** — Docker-executed verification with seccomp + no-network.  
 - **PII Calibration** — Shannon entropy thresholds with a 550-item dataset.  
 - **Observability First** — OTEL traces, Prometheus metrics, Grafana dashboards.  
-- **CI/CD** — GitHub Actions with healthchecks and hooks for shadow/canary logic.  
-- **Interactive Web UI** — Vite-powered React dashboard with Monaco editor.  
-- **SymPy & SciPy Demos** — quadratic solving and sine integration.  
+- **CI/CD** — GitHub Actions with healthchecks and hooks for shadow/canary logic.
+- **Interactive Web UI** — Vite-powered React dashboard with Monaco editor.
+- **SymPy & SciPy Demos** — quadratic solving and sine integration.
+- **Firecrawl Web Ingestion** — crawl websites, extract headings, embed pages, and compute sitemap coverage ratios.
 
 See the [User Manual](docs/USER_MANUAL.md) for a complete guide.
 


### PR DESCRIPTION
## Summary
- add Firecrawl Web Ingestion bullet to feature list in README
- clarify Firecrawl feature description in README

## Testing
- `cd ui && npm run test:ci`
- `cd ui && npm run build`
- `cd server && npm run test:ci`
- `cd server && npm run build`
- `pre-commit run --files README.md`
- `npm run docs:build` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68bcff49a158832a852afe3c7246395c