### PR TITLE
chore: use setup-node pnpm cache

### DIFF
--- a/.github/workflows/ci-full-and-smoke.yml
+++ b/.github/workflows/ci-full-and-smoke.yml
@@ -12,6 +12,11 @@ jobs:
     container: node:22-bullseye
     steps:
       - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: ui/pnpm-lock.yaml
       - run: corepack enable && corepack prepare pnpm@9.12.0 --activate
       - name: Sanitize proxy env (global)
         shell: bash
@@ -22,11 +27,6 @@ jobs:
           npm config delete https-proxy || true
           echo "Global proxy config removed"
         working-directory: ui
-      - uses: actions/cache@v4
-        with:
-          path: ~/.local/share/pnpm/store/v3
-          key: ${{ runner.os }}-ui-pnpm-${{ hashFiles('ui/pnpm-lock.yaml') }}
-          restore-keys: ${{ runner.os }}-ui-pnpm-
       - uses: actions/cache@v4
         with:
           path: ui/node_modules/.vite
@@ -84,6 +84,11 @@ jobs:
     container: node:22-bullseye
     steps:
       - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: ui/pnpm-lock.yaml
       - run: corepack enable && corepack prepare pnpm@9.12.0 --activate
       - name: Sanitize proxy env (global)
         shell: bash
@@ -94,11 +99,6 @@ jobs:
           npm config delete https-proxy || true
           echo "Global proxy config removed"
         working-directory: ui
-      - uses: actions/cache@v4
-        with:
-          path: ~/.local/share/pnpm/store/v3
-          key: ${{ runner.os }}-ui-pnpm-${{ hashFiles('ui/pnpm-lock.yaml') }}
-          restore-keys: ${{ runner.os }}-ui-pnpm-
       - uses: actions/cache@v4
         with:
           path: ui/node_modules/.vite

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,11 @@ jobs:
     container: node:22-bullseye
     steps:
       - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: ui/pnpm-lock.yaml
       - run: corepack enable && corepack prepare pnpm@9.12.0 --activate
       - name: Sanitize proxy env (global)
         shell: bash
@@ -22,11 +27,6 @@ jobs:
           npm config delete https-proxy || true
           echo "Global proxy config removed"
         working-directory: ui
-      - uses: actions/cache@v4
-        with:
-          path: ~/.local/share/pnpm/store/v3
-          key: ${{ runner.os }}-ui-pnpm-${{ hashFiles('ui/pnpm-lock.yaml') }}
-          restore-keys: ${{ runner.os }}-ui-pnpm-
       - uses: actions/cache@v4
         with:
           path: ui/node_modules/.vite

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,12 +14,12 @@ jobs:
     defaults: { run: { working-directory: ui } }
     steps:
       - uses: actions/checkout@v5
-      - run: corepack enable && corepack prepare pnpm@9.12.0 --activate
-      - uses: actions/cache@v4
+      - uses: actions/setup-node@v4
         with:
-          path: ~/.local/share/pnpm/store/v3
-          key: ${{ runner.os }}-ui-pnpm-${{ hashFiles('ui/pnpm-lock.yaml') }}
-          restore-keys: ${{ runner.os }}-ui-pnpm-
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: ui/pnpm-lock.yaml
+      - run: corepack enable && corepack prepare pnpm@9.12.0 --activate
       - uses: actions/cache@v4
         with:
           path: ui/node_modules/.vite
@@ -72,7 +72,7 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt', 'requirements-dev.txt', 'src/gateway/requirements.txt') }}
           restore-keys: ${{ runner.os }}-pip-
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Summary
- use `actions/setup-node@v4` with built-in pnpm caching
- cache Python dependencies using requirement file hashes

## Testing
- `pre-commit run --files .github/workflows/ci.yml .github/workflows/nightly.yml .github/workflows/ci-full-and-smoke.yml`

------
https://chatgpt.com/codex/tasks/task_b_68be0526f620832aab6e10f5842768a7