### PR TITLE
feat: allow recheck via label

### DIFF
--- a/.github/workflows/recheck.yml
+++ b/.github/workflows/recheck.yml
@@ -1,0 +1,20 @@
+name: Recheck CI
+on:
+  pull_request:
+    types:
+      - labeled
+jobs:
+  trigger:
+    if: github.event.label.name == 'recheck'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch CI workflow
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'ci.yml',
+              ref: context.payload.pull_request.head.ref
+            })


### PR DESCRIPTION
## Summary
- trigger CI re-run when `recheck` label is applied to a PR

## Testing
- `pre-commit run --files .github/workflows/recheck.yml`

------
https://chatgpt.com/codex/tasks/task_b_68be063f074c832a8dd2771d0fb9739c