### PR TITLE
ci: add concurrency and artifact retention

### DIFF
--- a/.github/workflows/ci-full-and-smoke.yml
+++ b/.github/workflows/ci-full-and-smoke.yml
@@ -1,3 +1,6 @@
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 name: CI Full and Smoke
 on:
   push: { branches: [main] }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,6 @@
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 name: CI
 on:
   push: { branches: [main] }

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,3 +1,6 @@
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 name: CodeQL
 
 on:

--- a/.github/workflows/codex-exec.yml
+++ b/.github/workflows/codex-exec.yml
@@ -1,3 +1,6 @@
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 name: Codex Exec (Node 22)
 on:
   workflow_dispatch:

--- a/.github/workflows/commit-messages.yml
+++ b/.github/workflows/commit-messages.yml
@@ -1,3 +1,6 @@
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 name: Commit Messages (Conventional Commits)
 
 on:

--- a/.github/workflows/dep-verify.yml
+++ b/.github/workflows/dep-verify.yml
@@ -1,13 +1,12 @@
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 name: Dep Verify (Install • Typecheck • Build • Test • Coverage)
 
 on:
   pull_request:
     branches: [ main ]
   workflow_dispatch:
-
-concurrency:
-  group: dep-verify-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,3 +1,6 @@
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 name: Nightly
 on:
   schedule:

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,3 +1,6 @@
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 name: PR Title (Conventional Commits)
 
 on:

--- a/.github/workflows/recheck.yml
+++ b/.github/workflows/recheck.yml
@@ -1,3 +1,6 @@
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 name: Recheck CI
 on:
   pull_request:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,3 +1,6 @@
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 name: release-please
 
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,6 @@
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 name: Release
 
 on:
@@ -84,12 +87,14 @@ jobs:
         with:
           name: ui-dist-${{ github.ref_name }}.tar.gz
           path: ui-dist-${{ github.ref_name }}.tar.gz
+          retention-days: 14
 
       - name: Upload SBOM
         uses: actions/upload-artifact@v4
         with:
           name: sbom-${{ github.ref_name }}.spdx.json
           path: sbom-${{ github.ref_name }}.spdx.json
+          retention-days: 14
 
   provenance:
     needs: build

--- a/.github/workflows/ui-build.yml
+++ b/.github/workflows/ui-build.yml
@@ -1,3 +1,6 @@
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 name: UI Build
 
 on:
@@ -34,4 +37,5 @@ jobs:
         with:
           name: ui-dist
           path: ui/dist
+          retention-days: 14
 


### PR DESCRIPTION
## Summary
- add concurrency guard to all workflows
- retain uploaded artifacts for 14 days

## Testing
- `pre-commit run --files .github/workflows/ci-full-and-smoke.yml .github/workflows/ci.yml .github/workflows/codeql.yml .github/workflows/codex-exec.yml .github/workflows/commit-messages.yml .github/workflows/dep-verify.yml .github/workflows/nightly.yml .github/workflows/pr-title.yml .github/workflows/recheck.yml .github/workflows/release-please.yml .github/workflows/release.yml .github/workflows/ui-build.yml`


------
https://chatgpt.com/codex/tasks/task_b_68be06d623d0832aadacd59ab4848f78