### PR TITLE
ci: use pnpm/action-setup for ui full and smoke workflows

### DIFF
--- a/.github/workflows/ci-full-and-smoke.yml
+++ b/.github/workflows/ci-full-and-smoke.yml
@@ -20,7 +20,11 @@ jobs:
           node-version: 22
           cache: pnpm
           cache-dependency-path: ui/pnpm-lock.yaml
-      - run: corepack enable && corepack prepare pnpm@9.12.0 --activate
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+          run_install: false
       - name: Sanitize proxy env (global)
         shell: bash
         run: |
@@ -92,7 +96,11 @@ jobs:
           node-version: 22
           cache: pnpm
           cache-dependency-path: ui/pnpm-lock.yaml
-      - run: corepack enable && corepack prepare pnpm@9.12.0 --activate
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+          run_install: false
       - name: Sanitize proxy env (global)
         shell: bash
         run: |


### PR DESCRIPTION
## Summary
- install pnpm via pnpm/action-setup in ui_smoke and ui_full jobs
- remove corepack pnpm preparation steps

## Testing
- `pre-commit run --files .github/workflows/ci-full-and-smoke.yml`


------
https://chatgpt.com/codex/tasks/task_b_68be10dc9e70832a96e7036527211a93