### PR TITLE
ci: setup pnpm in nightly workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -22,7 +22,11 @@ jobs:
           node-version: 22
           cache: pnpm
           cache-dependency-path: ui/pnpm-lock.yaml
-      - run: corepack enable && corepack prepare pnpm@9.12.0 --activate
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+          run_install: false
       - uses: actions/cache@v4
         with:
           path: ui/node_modules/.vite


### PR DESCRIPTION
## Summary
- use pnpm/action-setup in Nightly UI job
- drop manual corepack pnpm activation

## Testing
- `pre-commit run --files .github/workflows/nightly.yml`

------
https://chatgpt.com/codex/tasks/task_b_68be1555ac38832a9a2c2d7aeb9308d6