### PR TITLE
ci: use pnpm action in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,10 @@ jobs:
           node-version: 22
           cache: pnpm
           cache-dependency-path: ui/pnpm-lock.yaml
-
-      - run: corepack enable && corepack prepare pnpm@9.12.0 --activate
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.12.0
 
       - name: Install and build UI
         working-directory: ui


### PR DESCRIPTION
## Summary
- use pnpm/action-setup in release pipeline

## Testing
- `pre-commit run --files .github/workflows/release.yml`


------
https://chatgpt.com/codex/tasks/task_b_68be165a8f2c832ab25ca224eb43e0b4