### PR TITLE
ci: setup pnpm in codex exec workflow

### DIFF
--- a/.github/workflows/codex-exec.yml
+++ b/.github/workflows/codex-exec.yml
@@ -17,6 +17,9 @@ jobs:
     defaults: { run: { working-directory: ui } }
     steps:
       - uses: actions/checkout@v5
-      - run: corepack enable && corepack prepare pnpm@9.12.0 --activate
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
       - run: ${{ inputs.command }}
         env: { CI: "true" }


### PR DESCRIPTION
## Summary
- add pnpm/action-setup step to Codex Exec workflow
- drop corepack pnpm activation

## Testing
- `pre-commit run --files .github/workflows/codex-exec.yml`


------
https://chatgpt.com/codex/tasks/task_b_68be18b76d68832a92ba436c3cc40f09