### PR TITLE
ci: run pnpm setup before node cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,16 +15,16 @@ jobs:
     container: node:22-bullseye
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: pnpm
-          cache-dependency-path: ui/pnpm-lock.yaml
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
           version: 9
           run_install: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: ui/pnpm-lock.yaml
       - name: Sanitize proxy env (global)
         shell: bash
         run: |


### PR DESCRIPTION
## Summary
- ensure pnpm is installed before setup-node caching in ui workflow

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `git push` *(fails: No configured push destination)*

------
https://chatgpt.com/codex/tasks/task_b_68be1c302df4832aac6c6ad25be662a3