### PR TITLE
ci: setup pnpm in workflows

### DIFF
--- a/.github/workflows/ci-full-and-smoke.yml
+++ b/.github/workflows/ci-full-and-smoke.yml
@@ -15,15 +15,14 @@ jobs:
     container: node:22-bullseye
     steps:
       - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.12.0
       - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm
           cache-dependency-path: ui/pnpm-lock.yaml
-      - name: Enable corepack & pin pnpm
-        run: |
-          corepack enable
-          corepack prepare pnpm@9.12.0 --activate
       - name: Sanitize proxy env (global)
         shell: bash
         run: |
@@ -90,15 +89,14 @@ jobs:
     container: node:22-bullseye
     steps:
       - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.12.0
       - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm
           cache-dependency-path: ui/pnpm-lock.yaml
-      - name: Enable corepack & pin pnpm
-        run: |
-          corepack enable
-          corepack prepare pnpm@9.12.0 --activate
       - name: Sanitize proxy env (global)
         shell: bash
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,15 +15,14 @@ jobs:
     container: node:22-bullseye
     steps:
       - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.12.0
       - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm
           cache-dependency-path: ui/pnpm-lock.yaml
-      - name: Enable corepack & pin pnpm
-        run: |
-          corepack enable
-          corepack prepare pnpm@9.12.0 --activate
       - name: Sanitize proxy env (global)
         shell: bash
         run: |

--- a/.github/workflows/codex-exec.yml
+++ b/.github/workflows/codex-exec.yml
@@ -17,14 +17,13 @@ jobs:
     defaults: { run: { working-directory: ui } }
     steps:
       - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.12.0
       - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm
           cache-dependency-path: ui/pnpm-lock.yaml
-      - name: Enable corepack & pin pnpm
-        run: |
-          corepack enable
-          corepack prepare pnpm@9.12.0 --activate
       - run: ${{ inputs.command }}
         env: { CI: "true" }

--- a/.github/workflows/dep-verify.yml
+++ b/.github/workflows/dep-verify.yml
@@ -23,16 +23,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.12.0
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm
           cache-dependency-path: ui/pnpm-lock.yaml
-      - name: Enable corepack & pin pnpm
-        run: |
-          corepack enable
-          corepack prepare pnpm@9.12.0 --activate
 
       - name: Install
         run: pnpm i --frozen-lockfile

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,15 +17,14 @@ jobs:
     defaults: { run: { working-directory: ui } }
     steps:
       - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.12.0
       - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm
           cache-dependency-path: ui/pnpm-lock.yaml
-      - name: Enable corepack & pin pnpm
-        run: |
-          corepack enable
-          corepack prepare pnpm@9.12.0 --activate
       - uses: actions/cache@v4
         with:
           path: ui/node_modules/.vite

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,15 +22,14 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.12.0
       - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm
           cache-dependency-path: ui/pnpm-lock.yaml
-      - name: Enable corepack & pin pnpm
-        run: |
-          corepack enable
-          corepack prepare pnpm@9.12.0 --activate
 
       - name: Install and build UI
         working-directory: ui

--- a/.github/workflows/ui-build.yml
+++ b/.github/workflows/ui-build.yml
@@ -16,15 +16,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.12.0
       - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm
           cache-dependency-path: ui/pnpm-lock.yaml
-      - name: Enable corepack & pin pnpm
-        run: |
-          corepack enable
-          corepack prepare pnpm@9.12.0 --activate
 
       - name: Install dependencies
         working-directory: ui


### PR DESCRIPTION
## Summary
- set up pnpm via pnpm/action-setup before Node installation in workflows
- remove redundant corepack steps

## Testing
- `pre-commit run --files .github/workflows/ci-full-and-smoke.yml .github/workflows/ci.yml .github/workflows/codex-exec.yml .github/workflows/dep-verify.yml .github/workflows/nightly.yml .github/workflows/release.yml .github/workflows/ui-build.yml`


------
https://chatgpt.com/codex/tasks/task_b_68be870a5a0c832a979abe2512d19571