### PR TITLE
chore(ci): cache pnpm in UI smoke/full workflows

### DIFF
--- a/.github/workflows/ci-full-and-smoke.yml
+++ b/.github/workflows/ci-full-and-smoke.yml
@@ -15,13 +15,14 @@ jobs:
     container: node:22-bullseye
     steps:
       - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 9.12.0
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: pnpm
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.12.0
+          run_install: false
+          cache: true
           cache-dependency-path: ui/pnpm-lock.yaml
       - name: Sanitize proxy env (global)
         shell: bash
@@ -89,13 +90,14 @@ jobs:
     container: node:22-bullseye
     steps:
       - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 9.12.0
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: pnpm
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.12.0
+          run_install: false
+          cache: true
           cache-dependency-path: ui/pnpm-lock.yaml
       - name: Sanitize proxy env (global)
         shell: bash


### PR DESCRIPTION
## Summary
- optimize UI smoke and full jobs to use pnpm/action-setup caching

## Testing
- `pre-commit run --files .github/workflows/ci-full-and-smoke.yml`


------
https://chatgpt.com/codex/tasks/task_b_68be98174544832a9bd1a8d07cf9ee69