### PR TITLE
chore: fix pnpm setup order in dep verify workflow

### DIFF
--- a/.github/workflows/dep-verify.yml
+++ b/.github/workflows/dep-verify.yml
@@ -23,14 +23,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 9.12.0
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: pnpm
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.12.0
+          cache: true
           cache-dependency-path: ui/pnpm-lock.yaml
 
       - name: Install


### PR DESCRIPTION
## Summary
- set up Node before pnpm in dep verify UI job
- enable pnpm/action-setup cache using lockfile

## Testing
- `pre-commit run --files .github/workflows/dep-verify.yml`

------
https://chatgpt.com/codex/tasks/task_b_68be99deb55c832ab7043907613cd73e