### PR TITLE
refactor: enable pnpm cache in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,13 +22,14 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 9.12.0
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: pnpm
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.12.0
+          run_install: false
+          cache: true
           cache-dependency-path: ui/pnpm-lock.yaml
 
       - name: Install and build UI


### PR DESCRIPTION
## Summary
- enable pnpm caching in release build workflow

## Testing
- `python3 -m pre_commit run --files .github/workflows/release.yml`

------
https://chatgpt.com/codex/tasks/task_b_68be9b4b7a94832aa6895de4a4e9ed4d