### PR TITLE
chore: update pnpm setup in ui build workflow

### DIFF
--- a/.github/workflows/ui-build.yml
+++ b/.github/workflows/ui-build.yml
@@ -16,13 +16,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 9.12.0
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: pnpm
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.12.0
+          run_install: false
+          cache: true
           cache-dependency-path: ui/pnpm-lock.yaml
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- configure node before pnpm in UI build workflow
- enable caching via pnpm/action-setup instead of setup-node

## Testing
- `pre-commit run --files .github/workflows/ui-build.yml`


------
https://chatgpt.com/codex/tasks/task_b_68beacc35488832a8ebd8a04eb4fb830