### PR TITLE
chore: fix pnpm setup order in codex exec workflow

### DIFF
--- a/.github/workflows/codex-exec.yml
+++ b/.github/workflows/codex-exec.yml
@@ -17,13 +17,14 @@ jobs:
     defaults: { run: { working-directory: ui } }
     steps:
       - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 9.12.0
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: pnpm
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.12.0
+          run_install: false
+          cache: true
           cache-dependency-path: ui/pnpm-lock.yaml
       - run: ${{ inputs.command }}
         env: { CI: "true" }


### PR DESCRIPTION
## Summary
- avoid pnpm use before node setup in Codex exec workflow

## Testing
- `pre-commit run --files .github/workflows/codex-exec.yml`


------
https://chatgpt.com/codex/tasks/task_b_68beae608fac832ab4cf30bdd8c0a5c0