### PR TITLE
chore(deps): ignore vite plugin in ui dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
   - package-ecosystem: "npm"
     directory: "/ui"
     schedule: { interval: "weekly" }
+    ignore:
+      - dependency-name: "@vitejs/plugin-react"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule: { interval: "weekly" }


### PR DESCRIPTION
## Summary
- ignore @vitejs/plugin-react in Dependabot for /ui

## Testing
- `pre-commit run --files .github/dependabot.yml`


------
https://chatgpt.com/codex/tasks/task_b_68bf8be07838832ab9bddd8b721ef841