### PR TITLE
refactor(ui): enhance test utilities

### DIFF
--- a/ui/src/test-utils.tsx
+++ b/ui/src/test-utils.tsx
@@ -1,10 +1,33 @@
-import type { ReactElement } from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import React, { ReactElement, ReactNode } from 'react';
+import {
+  render,
+  renderHook,
+  RenderHookOptions,
+  RenderHookResult,
+  RenderOptions,
+  RenderResult,
+} from '@testing-library/react';
 
-export function renderWithProviders(ui: ReactElement) {
+type WrapperProps = { children: ReactNode };
+
+function TestProviders({ children }: WrapperProps) {
   // Extend here with providers if needed (Router, QueryClient, etc.)
-  return render(ui);
+  return <>{children}</>;
 }
 
-export { screen, waitFor };
+export function renderWithProviders(
+  ui: ReactElement,
+  options?: Omit<RenderOptions, 'wrapper'>
+): RenderResult {
+  return render(ui, { wrapper: TestProviders, ...options });
+}
+
+export function renderHookWithProviders<Result, Props>(
+  hook: (initialProps: Props) => Result,
+  options?: Omit<RenderHookOptions<Props>, 'wrapper'>
+): RenderHookResult<Result, Props> {
+  return renderHook(hook, { wrapper: TestProviders, ...options });
+}
+
+export * from '@testing-library/react';
 


### PR DESCRIPTION
## Summary
- add provider wrapper utilities for rendering components and hooks in tests
- re-export testing library helpers

## Testing
- `pnpm -C ui typecheck`
- `pnpm -C ui build`
- `pnpm -C ui test:ci`


------
https://chatgpt.com/codex/tasks/task_b_68bf8d9bd204832aafffbccf542afaa8