### PR TITLE
docs: clarify canonical roadmap

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,7 @@
 - Breaking changes: open an **RFC** issue before implementation.
 - Add/update tests or validation scripts for logic changes.
 - Keep `providers.yaml` schema-valid (`npm run validate:providers`).
+- The canonical roadmap lives in `ROADMAP.md`; update it when changes affect project direction.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary
- document that ROADMAP.md is the canonical roadmap file

## Testing
- `pre-commit run --files CONTRIBUTING.md -v`


------
https://chatgpt.com/codex/tasks/task_b_68bfa0f01d58832a8d3734fd5a8c44de