### PR TITLE
docs: AgentOps + Agentic RAG + Contracts (from Agents Companion PDF)

### DIFF
--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -19,6 +19,7 @@
 - **Firecrawl (Web Crawl & Extract)** — [mendableai/firecrawl](https://github.com/mendableai/firecrawl)  
 - **Gitingest (Repo → Digest)** — [kurtosis-tech/gitingest](https://github.com/kurtosis-tech/gitingest)  
 - **Tensorlake (Metadata-RAG)** — [tensorlakeai/tensorlake](https://github.com/tensorlakeai/tensorlake)  
+- **Agentic RAG (overview & patterns)** — (internal) *Agents Companion, Feb 2025 PDF*
 
 ## Multi-Agent Runtimes
 - **AgentScope** — [agentscope/agentscope](https://github.com/agentscope/agentscope)  
@@ -66,6 +67,11 @@
 ## Agent Learning & Evolution
 - **Agent Lightning (Offline RL for Agents)** — [huggingface.co/papers/2409.00422](https://huggingface.co/papers/2409.00422)
 - **AlphaEvolve (Evolutionary Optimization)** — [arXiv:2409.00567](https://arxiv.org/abs/2409.00567)
+
+## AgentOps & Contracts
+- **Agent evaluation (trajectory, final response, HITL) & multi-agent scalability** — (internal) *Agents Companion, Feb 2025 PDF*
+- **Contract-adhering agents (contracts, negotiation, subcontracts, lifecycle)** — (internal) *Agents Companion, Feb 2025 PDF*
+
 
 ## Research Orchestration
 - **Nebius UDR (Universal Deep Research)** — https://github.com/demianarc/nebiusaistudiodeepresearch


### PR DESCRIPTION
## Summary
- expand roadmap with AgentOps maturity and Agentic RAG integration
- add Contractor agent patterns and AgentOps evaluators to roadmap
- reference Agentic RAG and AgentOps/Contracts material in REFERENCES

## Testing
- `npx markdownlint-cli2 "docs/**/*.md" "REFERENCES.md" "ROADMAP.md"` *(fails: Summary: 410 error(s))*
- `pre-commit run --files ROADMAP.md REFERENCES.md`

------
https://chatgpt.com/codex/tasks/task_b_68bfa1558bd8832a90446e84ee2cdf08