### PR TITLE
chore: add markdownlint ignore file

### DIFF
--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+build
+coverage
+.next
+CHANGELOG.md


### PR DESCRIPTION
## Summary
- add `.markdownlintignore` to exclude directories and changelog from linting

## Testing
- `pre-commit run --files .markdownlintignore`

------
https://chatgpt.com/codex/tasks/task_b_68bfaad2df6c832a97e925cb7b7188fd