### PR TITLE
test: cover renderHookWithProviders

### DIFF
--- a/ui/src/test-utils.test.tsx
+++ b/ui/src/test-utils.test.tsx
@@ -1,4 +1,9 @@
-import { renderWithProviders, screen, waitFor } from './test-utils';
+import {
+  renderWithProviders,
+  renderHookWithProviders,
+  screen,
+  waitFor,
+} from './test-utils';
 import { useEffect, useState } from 'react';
 import { describe, it, expect } from 'vitest';
 
@@ -19,5 +24,20 @@ describe('renderWithProviders', () => {
     await waitFor(() => {
       expect(screen.getByText('loaded')).toBeInTheDocument();
     });
+  });
+});
+
+describe('renderHookWithProviders', () => {
+  function useTestHook(initialValue: string) {
+    const [value] = useState(initialValue);
+    return value;
+  }
+
+  it('passes initial props to the hook', () => {
+    const { result } = renderHookWithProviders(useTestHook, {
+      initialProps: 'hello',
+    });
+
+    expect(result.current).toBe('hello');
   });
 });


### PR DESCRIPTION
## Summary
- test renderHookWithProviders using initial props

## Testing
- `npm run test:coverage -- src/test-utils.test.tsx`


------
https://chatgpt.com/codex/tasks/task_b_68c0548961b0832a93e6503c43162142