### PR TITLE
test: add npm test script for server

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,14 @@ npm run dev
 The dev server runs on <http://localhost:5173>. Set `VITE_SOCKET_BASE_URL` if your backend isn't at
 `http://localhost:4000`.
 
+## Run the server tests locally
+
+```bash
+npm test -C server
+```
+
+Runs the server's Vitest test suite.
+
 ### Pre-commit Hooks
 
 We enforce ESLint/Prettier and other checks via [pre-commit](https://pre-commit.com/).

--- a/server/package.json
+++ b/server/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "lint": "tsc --noEmit",
     "build": "tsc -p tsconfig.json",
+    "test": "vitest",
     "test:ci": "vitest run --coverage"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- add vitest test script for server
- document server test command in contributing guide

## Testing
- `npm test -C server`
- `pre-commit run --files server/package.json CONTRIBUTING.md`


------
https://chatgpt.com/codex/tasks/task_b_68c11ff8a718832aa0ef39d904d5542e