### PR TITLE
docs: add MetaCLIP2 roadmap item

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -324,6 +324,10 @@ constitutional bypass.
 - **Scientific Code Pipelines:** agentic planning → code generation → experiment orchestration →
   evaluation loops tailored for empirical/scientific software; design informed by recent research on
   AI systems that help scientists write expert-level empirical software.
+- **Multimodal Search & Retrieval (MetaCLIP2)** — multilingual image↔text embeddings for cross-modal
+  search, screenshot/diagram grounding, and gallery/asset retrieval. Integrates with Evidence Store so
+  citations can reference an image region + text span. Enables hybrid RAG where visual evidence is
+  retrieved alongside text passages.
 
 ---
 


### PR DESCRIPTION
## Summary
- add MetaCLIP2 multimodal search & retrieval capability to roadmap

## Testing
- `npm run md:lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68c635863b34832a8a7d160dc470eb34