### PR TITLE
docs: add MetaCLIP2 adapter to roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -83,6 +83,7 @@ through AnyLLM (plus official SDKs). Safety via NeMo Guardrails / Guardrails AI.
     Engine gates (rate/role/domain allowlists), consent prompts, and full trace/provenance.
     - Supports read/fetch and write/actions (e.g., Jira ticket updates, GitHub ops, Slack/Zapier
       flows); composable in multi-tool chains with policy & audit.
+  - Vision embeddings: **MetaCLIP2** adapter (encode image/text queries; multilingual).
 
 - **Memory Fabric** — Episodic/semantic/skills; vector+graph (Qdrant/Weaviate/Graph store);
   retrieval policies; decision narratives.


### PR DESCRIPTION
## Summary
- document MetaCLIP2 vision embeddings adapter in the Tool/Skill Registry

## Testing
- `npm run md:lint`
- `npm test` *(fails: KeyboardInterrupt)*
- `pytest tests/test_examples.py::test_sympy_demo_run_module -q`


------
https://chatgpt.com/codex/tasks/task_b_68c63c3d2820832aa82f1508158dec8c