### PR TITLE
docs: note MetaCLIP2 routing fallback

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -316,6 +316,8 @@ constitutional bypass.
 
 - ERNIE X1.1 is selectable under the Cloud Pool for reasoning/verification tasks, subject to API
   access, latency, and cost.
+- Router prefers **MetaCLIP2** for cross-modal queries; falls back to text-only retrieval if no
+  visual candidates or low similarity.
 
 ### Local
 


### PR DESCRIPTION
## Summary
- document MetaCLIP2 router preference with text-only fallback

## Testing
- `pre-commit run --files ROADMAP.md`
- `pytest tests/test_examples.py`


------
https://chatgpt.com/codex/tasks/task_b_68c63ff9bf78832a8e207cda2bd507bb