### PR TITLE
docs: expand Phase D multimodal deliverables

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -412,11 +412,13 @@ constitutional bypass.
 - ASR/TTS (Parlant/VibeVoice/DIA)
 - PDF/OCR (PyMuPDF/Tesseract)
 - Playwright browser agent
-- Fusion Controller (multimodal I/O)  
+- Fusion Controller (multimodal I/O)
+- **MetaCLIP2** embedding service + vector index; image region extraction (saliency or OCR blocks); Studio preview for visual citations.
   **Exit Criteria:**
 - Voice roundtrip working
 - PDF → structured JSON
 - Browser agent completes form
+- Cross-modal search demo (“find the whiteboard with graph about revenue”); answer includes **image region citation** and supporting text.
 
 ---
 


### PR DESCRIPTION
## Summary
- document MetaCLIP2 embedding service and visual citation capabilities in Phase D deliverables
- outline cross-modal search demo with image-region citations in Phase D exit criteria

## Testing
- `pytest` *(interrupted: KeyboardInterrupt after partial run, 15 passed)*

------
https://chatgpt.com/codex/tasks/task_b_68c640c3385c832a98484647896dbe0f