### PR TITLE
docs: add file/module backlog to roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -750,6 +750,15 @@ Every LLM span must include:
 
 ---
 
+## 11) File/Module Backlog
+
+- `integrations/vision/metaclip2/*` (encoder service, batching, health checks)
+- `evidence/vision/*` (image region store, thumbnails, mask/box metadata)
+- `evaluators/vision_grounding/*` (IoU, similarity thresholds, tests)
+- `studio/components/vision-citation/*` (UI overlay for boxes/masks)
+
+---
+
 ## Example Use Cases (Unlocked across roadmap)
 
 - Repo creation from spec (code+tests+CI+deploy).


### PR DESCRIPTION
## Summary
- document vision-related file/module backlog

## Testing
- `pre-commit run --files ROADMAP.md`
- `pytest` *(fails: KeyboardInterrupt, 15 passed, 2 warnings in 180.84s)*

------
https://chatgpt.com/codex/tasks/task_b_68c64f47b348832aa8f103b8c467402f