### PR TITLE
docs: add cross-modal and diagram use cases

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -759,7 +759,7 @@ Every LLM span must include:
 
 ---
 
-## Example Use Cases (Unlocked across roadmap)
+## 12) Example Use-Cases
 
 - Repo creation from spec (code+tests+CI+deploy).
 - PDF → tables/charts with sanity checks.
@@ -781,6 +781,8 @@ Every LLM span must include:
 - Federated task delegation between orgs.
 - Marketplace rentals of expert agents.
 - Strategic dialogues for corporate planning.
+- **Cross-modal incident triage** — search logs + screenshots ("error dialog about OAuth on staging") with visual box citation.
+- **Docs & diagrams** — retrieve architecture diagram segments that support a claim and cite the exact region.
 
 ---
 

--- a/docs/Naestro_ROADMAP.md
+++ b/docs/Naestro_ROADMAP.md
@@ -717,7 +717,7 @@ Every LLM span must include:
 
 ---
 
-## Example Use Cases (Unlocked across roadmap)
+## 12) Example Use-Cases
 
 - Repo creation from spec (code+tests+CI+deploy).
 - PDF → tables/charts with sanity checks.
@@ -737,5 +737,7 @@ Every LLM span must include:
 - Federated task delegation between orgs.
 - Marketplace rentals of expert agents.
 - Strategic dialogues for corporate planning.
+- **Cross-modal incident triage** — search logs + screenshots ("error dialog about OAuth on staging") with visual box citation.
+- **Docs & diagrams** — retrieve architecture diagram segments that support a claim and cite the exact region.
 
 ---


### PR DESCRIPTION
## Summary
- number roadmap use case section
- add cross-modal incident triage and docs/diagrams examples

## Testing
- `pre-commit run --files ROADMAP.md docs/Naestro_ROADMAP.md`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68c656a07bbc832a84fee21d6abcda0c