### PR TITLE
Add vision/multimodal references

### DIFF
--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -69,6 +69,12 @@ docs. Keep it authoritative and in sync with `ROADMAP.md`.
 - **Awesome-Nano-Banana-images (edge/device OS images; reference-only)** —
   <https://github.com/PicoTrex/Awesome-Nano-Banana-images>
 
+## Vision / Multimodal
+
+- **MetaCLIP2 (multilingual vision-text embeddings)** — <https://huggingface.co/docs/transformers/main/en/model_doc/metaclip2>
+- **Transformers (integration docs)** — <https://huggingface.co/docs/transformers/index>
+- **Text↔Image search notebook (example)** — <https://github.com/huggingface/notebooks/blob/main/examples/image_similarity.ipynb>
+
 ## Voice / Speech
 
 - **Parlant** — <https://github.com/parlant-io>


### PR DESCRIPTION
## Summary
- add Vision / Multimodal section in REFERENCES
- include links for MetaCLIP2, Transformers integration docs, and a text↔image search example notebook

## Testing
- `pre-commit run --files REFERENCES.md`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68c662fce1a0832ab1567d10c0d9d592