### PR TITLE
chore: add link-check script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "md:fix": "markdownlint-cli2 --fix \"**/*.md\"",
     "md:fmt": "prettier --write \"**/*.md\"",
     "md:check": "prettier --check \"**/*.md\" && markdownlint-cli2 \"**/*.md\" \"#**/node_modules\"",
+    "link-check": "npm run markdown-link-check",
     "markdown-link-check": "markdown-link-check REFERENCES.md ROADMAP.md",
     "test": "pytest"
   },


### PR DESCRIPTION
## Summary
- add `link-check` script to run existing markdown link checker

## Testing
- `npm test`
- `npm run link-check` *(fails: ReferenceError: File is not defined)*

------
https://chatgpt.com/codex/tasks/task_b_68c666d11be0832aa8815c02441aabe3