### PR TITLE
feat: Collaboration Modes & Depth + References Sync

### DIFF
--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -66,6 +66,8 @@ docs. Keep it authoritative and in sync with `ROADMAP.md`.
 - **finllm-apps (cross-framework finance agents)** — <https://github.com/tinztwins/finllm-apps>
 - **Nebius UDR (Universal Deep Research prototype)** —
   <https://github.com/demianarc/nebiusaistudiodeepresearch>
+- **SFR-DeepResearch (self-factored retrieval)** —
+  <https://github.com/arekfu/sfr-deep-research>
 - **Awesome-Nano-Banana-images (edge/device OS images; reference-only)** —
   <https://github.com/PicoTrex/Awesome-Nano-Banana-images>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -101,6 +101,9 @@ through AnyLLM (plus official SDKs). Safety via NeMo Guardrails / Guardrails AI.
   metrics. Selects optimal chunking strategy dynamically.
 - **PO Policy Module** — Preference optimization suite (PVPO/DCPO/…); stability/effectiveness
   monitors.
+- **Collaboration Modes & Depth** — Per-run preferences for orchestrator collaboration with
+  auto escalation, budgets, and answer strategies. See
+  [docs/orchestrator_collaboration.md](docs/orchestrator_collaboration.md).
 - **Runtime Adapters** — LangGraph/CrewAI/AgentScope/AutoGen/Agent Squad/Semantic Kernel/SuperAGI
   with policy/trace parity.
 - **Tokenomics Engine** — Credits/budgets; marketplace transactions.

--- a/docs/orchestrator_collaboration.md
+++ b/docs/orchestrator_collaboration.md
@@ -1,0 +1,37 @@
+# Orchestrator Collaboration Modes & Depth
+
+Naestro's orchestrator supports several collaboration strategies when coordinating with
+online models. These preferences control how aggressively the system fans out work across
+models and how much autonomy the router has to escalate.
+
+## Modes
+
+- **solo** – run locally without consulting other models.
+- **consult** – issue a single query to an online model and return.
+- **collaborate** – delegate roles (Researcher, Coder, Reviewer) to multiple models.
+- **consensus** – collaborate and require models to vote before responding.
+- **swarm** – run structured debates across many models.
+
+## Depth
+
+Depth tunes the intensity of collaboration. `0` is minimal while `3` is exhaustive.
+
+## Additional Flags
+
+- **auto** – allow the router to escalate mode/depth if confidence is low and
+  budget and latency caps permit.
+- **ask_online** – when `false`, all cloud calls are blocked.
+- **budget_usd** – maximum spend for the run.
+- **p95_latency_s** – target 95th percentile latency.
+- **answer_strategy** – one of `self_if_confident`, `aggregate_always`,
+  `ask_clarify_below_threshold` (requires `confidence_threshold`).
+
+## Telemetry
+
+Runs emit OpenTelemetry/Prometheus metrics prefixed with `orch.` capturing the selected
+mode, depth, auto flag, budgets, and whether an automatic escalation occurred.
+
+## References
+
+See [`ROADMAP.md`](./ROADMAP.md) for upcoming work integrating these preferences
+throughout the planner, router, prompt composer, and UI.


### PR DESCRIPTION
## Summary
- document orchestrator collaboration modes and depth
- add roadmap bullet referencing new collaboration doc
- sync references with additional SFR-DeepResearch project

## Testing
- `pnpm -C ui test:ci`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68c68b779078832aa105c5b18fae86da