### PR TITLE
Add collaboration policy enforcement

### DIFF
--- a/router/__init__.py
+++ b/router/__init__.py
@@ -1,0 +1,6 @@
+"""Routing utilities with collaboration policy support."""
+
+from .collab_policy import CollaborationMode, CollaborationPolicy
+from .router import Router
+
+__all__ = ["CollaborationMode", "CollaborationPolicy", "Router"]

--- a/router/collab_policy.py
+++ b/router/collab_policy.py
@@ -1,0 +1,63 @@
+"""Collaboration policy definitions and enforcement."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class CollaborationMode(str, Enum):
+    """Supported collaboration modes."""
+
+    SOLO = "solo"
+    CONSULT = "consult"
+    COLLABORATE = "collaborate"
+    CONSENSUS = "consensus"
+    SWARM = "swarm"
+
+
+@dataclass(frozen=True)
+class PolicyRule:
+    """Rule describing allowed agent counts for a mode."""
+
+    min_agents: int
+    max_agents: int | None = None
+
+
+class CollaborationPolicy:
+    """Collection of collaboration policy rules.
+
+    The policy enforces simple numerical constraints on the number of agents
+    involved in a request.  More sophisticated behaviour can be layered on top
+    by callers as needed.
+    """
+
+    RULES: dict[CollaborationMode, PolicyRule] = {
+        CollaborationMode.SOLO: PolicyRule(min_agents=1, max_agents=1),
+        CollaborationMode.CONSULT: PolicyRule(min_agents=1, max_agents=2),
+        CollaborationMode.COLLABORATE: PolicyRule(min_agents=2),
+        CollaborationMode.CONSENSUS: PolicyRule(min_agents=2),
+        CollaborationMode.SWARM: PolicyRule(min_agents=3),
+    }
+
+    @classmethod
+    def enforce(cls, mode: CollaborationMode, num_agents: int) -> None:
+        """Ensure ``num_agents`` satisfies the policy for ``mode``.
+
+        Args:
+            mode: The collaboration mode being used.
+            num_agents: Number of participating agents.
+
+        Raises:
+            ValueError: If the policy for ``mode`` is violated.
+        """
+
+        rule = cls.RULES[mode]
+        if num_agents < rule.min_agents:
+            raise ValueError(
+                f"{mode.value} mode requires at least {rule.min_agents} agent(s)"
+            )
+        if rule.max_agents is not None and num_agents > rule.max_agents:
+            raise ValueError(
+                f"{mode.value} mode allows at most {rule.max_agents} agent(s)"
+            )

--- a/router/router.py
+++ b/router/router.py
@@ -1,0 +1,34 @@
+"""Simple router with collaboration policy enforcement."""
+
+from __future__ import annotations
+
+from typing import Iterable, Sequence
+
+from .collab_policy import CollaborationMode, CollaborationPolicy
+
+
+class Router:
+    """Route requests to agents while enforcing collaboration policy."""
+
+    def __init__(self, mode: CollaborationMode = CollaborationMode.SOLO) -> None:
+        self.mode = mode
+
+    def route(self, agents: Sequence[str] | Iterable[str]) -> Sequence[str]:
+        """Validate agents according to the configured mode.
+
+        The router itself does not perform any IO.  It simply checks the number
+        of agents against the collaboration policy and returns the sequence.
+
+        Args:
+            agents: Sequence of agent identifiers.
+
+        Returns:
+            The provided sequence of agents.
+
+        Raises:
+            ValueError: If the agent count violates the collaboration policy.
+        """
+
+        agents = list(agents)
+        CollaborationPolicy.enforce(self.mode, len(agents))
+        return agents

--- a/tests/router/test_collab_policy.py
+++ b/tests/router/test_collab_policy.py
@@ -1,0 +1,39 @@
+import pytest
+
+from router.collab_policy import CollaborationMode
+from router.router import Router
+
+
+def test_solo_only_allows_one_agent():
+    router = Router(CollaborationMode.SOLO)
+    assert router.route(["alice"]) == ["alice"]
+    with pytest.raises(ValueError):
+        router.route(["alice", "bob"])
+
+
+def test_consult_allows_two_agents_but_not_three():
+    router = Router(CollaborationMode.CONSULT)
+    assert router.route(["alice", "bob"]) == ["alice", "bob"]
+    with pytest.raises(ValueError):
+        router.route(["alice", "bob", "carol"])
+
+
+def test_collaborate_requires_at_least_two_agents():
+    router = Router(CollaborationMode.COLLABORATE)
+    with pytest.raises(ValueError):
+        router.route(["alice"])
+    assert router.route(["alice", "bob"]) == ["alice", "bob"]
+
+
+def test_consensus_requires_at_least_two_agents():
+    router = Router(CollaborationMode.CONSENSUS)
+    with pytest.raises(ValueError):
+        router.route(["alice"])
+    assert router.route(["alice", "bob"]) == ["alice", "bob"]
+
+
+def test_swarm_requires_three_agents():
+    router = Router(CollaborationMode.SWARM)
+    with pytest.raises(ValueError):
+        router.route(["alice", "bob"])
+    assert router.route(["alice", "bob", "carol"]) == ["alice", "bob", "carol"]


### PR DESCRIPTION
## Summary
- define collaboration policy rules for solo, consult, collaborate, consensus and swarm modes
- enforce collaboration policy in router
- add unit tests for collaboration policy

## Testing
- `pytest tests/router/test_collab_policy.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68c720d092a8832a924b8ec794831961