### PR TITLE
feat: require non-empty goal and cop header

### DIFF
--- a/schemas/plan.schema.json
+++ b/schemas/plan.schema.json
@@ -5,7 +5,7 @@
   "type": "object",
   "required": ["goal", "tasks", "inputs", "outputs", "collaboration", "cop_header"],
   "properties": {
-    "goal": { "type": "string" },
+    "goal": { "type": "string", "minLength": 1 },
     "tasks": { "type": "array", "items": { "type": "object" } },
     "inputs": { "type": "object" },
     "outputs": { "type": "object" },
@@ -24,7 +24,7 @@
       },
       "additionalProperties": false
     },
-    "cop_header": { "type": "string" }
+    "cop_header": { "type": "string", "minLength": 1 }
   },
   "additionalProperties": true
 }


### PR DESCRIPTION
## Summary
- enforce non-empty values for `goal` and `cop_header` in plan schema

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68c728ebb284832ab26bcc0b230f4c42