### PR TITLE
refactor planner prefs

### DIFF
--- a/tests/planner/test_collaboration.py
+++ b/tests/planner/test_collaboration.py
@@ -1,6 +1,9 @@
-from orchestrator.planner import compile_plan, DEFAULT_COLLAB_PREFS, clamp_prefs, compose_cop_header
 import json
-import pathlib
+
+import pytest
+
+from orchestrator.planner import DEFAULT_COLLAB_PREFS, clamp_prefs, compile_plan
+
 
 def test_defaults_and_header_snapshot():
     plan = compile_plan("Build X", tasks=[], inputs={}, outputs={}, overrides=None)
@@ -10,19 +13,22 @@ def test_defaults_and_header_snapshot():
     snap = json.dumps(plan, sort_keys=True)
     assert "collaboration" in snap and "cop_header" in snap
 
+
 def test_overrides_and_bounds():
     plan = compile_plan(
         "Goal",
-        overrides={"collaboration": {
-            "mode": "CONSULT_BAD",   # will clamp to default
-            "depth": 99,             # clamp to 3
-            "auto": False,
-            "ask_online": False,
-            "budget_usd": -1,        # clamp to 0
-            "p95_latency_s": -5,     # clamp to 0
-            "answer_strategy": "ask_clarify_below_threshold",
-            "confidence_threshold": 1.7  # clamp to 1
-        }}
+        overrides={
+            "collaboration": {
+                "mode": "CONSULT_BAD",  # will clamp to default
+                "depth": 99,  # clamp to 3
+                "auto": False,
+                "ask_online": False,
+                "budget_usd": -1,  # clamp to 0
+                "p95_latency_s": -5,  # clamp to 0
+                "answer_strategy": "ask_clarify_below_threshold",
+                "confidence_threshold": 1.7,  # clamp to 1
+            }
+        },
     )
     c = plan["collaboration"]
     assert c["mode"] == DEFAULT_COLLAB_PREFS["mode"]
@@ -32,12 +38,15 @@ def test_overrides_and_bounds():
     assert c["answer_strategy"] == "ask_clarify_below_threshold"
     assert c["confidence_threshold"] == 1.0
 
+
 def test_schema_validation():
-    try:
-        import jsonschema  # type: ignore
-    except Exception:
-        # allow passing when jsonschema isn't installed in CI image
-        return
-    # Will raise if invalid
+    pytest.importorskip("jsonschema")
     plan = compile_plan("Y", tasks=[], inputs={}, outputs={}, overrides=None)
     assert isinstance(plan, dict)
+
+
+def test_unknown_pref_keys_removed():
+    prefs = {"mode": "solo", "extra": 42}
+    clamped = clamp_prefs(prefs)
+    assert clamped["mode"] == "solo"
+    assert "extra" not in clamped


### PR DESCRIPTION
## Summary
- drop unknown collaboration preference keys
- test that extras are removed

## Testing
- `pre-commit run --files orchestrator/planner.py tests/planner/test_collaboration.py`
- `pytest tests/planner/test_collaboration.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68c729fc8ae0832aa89399e49b4156a2