### PR TITLE
Add lightweight telemetry metrics and instrumentation

### DIFF
--- a/router/router.py
+++ b/router/router.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Iterable, Sequence
 
 from .collab_policy import CollaborationMode, CollaborationPolicy
+from src.telemetry.metrics import collab_routes
 
 
 class Router:
@@ -31,4 +32,6 @@ class Router:
 
         agents = list(agents)
         CollaborationPolicy.enforce(self.mode, len(agents))
+        # Record the routing event for telemetry purposes.
+        collab_routes.inc(self.mode.value)
         return agents

--- a/src/gateway/main.py
+++ b/src/gateway/main.py
@@ -12,6 +12,7 @@ from fastapi import FastAPI, WebSocket
 from fastapi.responses import JSONResponse, StreamingResponse
 from starlette.websockets import WebSocketDisconnect
 from pydantic import BaseModel
+from src.telemetry.metrics import orchestrate_requests, telemetry_events
 
 app = FastAPI(title="NAESTRO Gateway")
 ORCH = os.getenv("ORCH_URL", "http://orchestrator:8081")
@@ -64,6 +65,7 @@ async def orchestrate(task: dict):
     """Proxy task execution to the orchestrator."""
 
     global REQUEST_COUNT, REQUEST_LATENCIES
+    orchestrate_requests.inc()
     start = time.perf_counter()
     async with httpx.AsyncClient(timeout=120) as client:
         try:
@@ -106,6 +108,7 @@ def _kpi_metrics() -> KPIMetrics:
 
 
 def _telemetry_event() -> Telemetry:
+    telemetry_events.inc()
     return Telemetry(
         timestamp=time.time(),
         system=_system_metrics(),

--- a/src/prompt/composer.py
+++ b/src/prompt/composer.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 from typing import Any, Dict, Iterable, List, Mapping
 
 from orchestrator.planner import clamp_prefs
+from src.telemetry.metrics import collab_prompts, collab_prompt_depth
 
 
 def _aggregate(responses: Iterable[Mapping[str, Any]]) -> str:
@@ -56,6 +57,9 @@ def add_collab_headers(prompt: str, prefs: Mapping[str, Any]) -> str:
     mode = cfg["mode"]
     depth = cfg["depth"]
     header = f"<<cop.mode:{mode}>> <<cop.depth:{depth}>>"
+    # Emit telemetry for prompt composition.
+    collab_prompts.inc(mode)
+    collab_prompt_depth.set(mode, depth)
     return f"{header}\n{prompt}"
 
 

--- a/src/telemetry/__init__.py
+++ b/src/telemetry/__init__.py
@@ -1,0 +1,21 @@
+"""Telemetry metrics for Naestro.
+
+Exposes lightweight counters and gauges used across the server, router and
+prompt layers.  The metrics are intentionally simple so they can operate in the
+unit test environment without any external dependencies."""
+
+from .metrics import (
+    collab_routes,
+    collab_prompts,
+    collab_prompt_depth,
+    orchestrate_requests,
+    telemetry_events,
+)
+
+__all__ = [
+    "collab_routes",
+    "collab_prompts",
+    "collab_prompt_depth",
+    "orchestrate_requests",
+    "telemetry_events",
+]

--- a/src/telemetry/metrics.py
+++ b/src/telemetry/metrics.py
@@ -1,0 +1,97 @@
+"""Lightweight metrics primitives used for unit tests.
+
+The real project is expected to use OpenTelemetry/Prometheus, but the test
+environment keeps dependencies to a minimum.  These classes mimic a tiny subset
+of the Prometheus client API so application code can instrument itself while the
+unit tests can assert on metric values.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Dict
+
+
+@dataclass
+class LabeledCounter:
+    """Counter supporting simple string labels."""
+
+    name: str
+    description: str
+    _values: Dict[str, int] = field(default_factory=lambda: defaultdict(int))
+
+    def inc(self, label: str, amount: int = 1) -> None:
+        self._values[label] += amount
+
+    def get(self, label: str) -> int:
+        return self._values[label]
+
+    def reset(self) -> None:
+        self._values.clear()
+
+
+@dataclass
+class SimpleCounter:
+    """Counter without labels."""
+
+    name: str
+    description: str
+    value: int = 0
+
+    def inc(self, amount: int = 1) -> None:
+        self.value += amount
+
+    def get(self) -> int:
+        return self.value
+
+    def reset(self) -> None:
+        self.value = 0
+
+
+@dataclass
+class LabeledGauge:
+    """Gauge storing the last value per label."""
+
+    name: str
+    description: str
+    _values: Dict[str, float] = field(default_factory=dict)
+
+    def set(self, label: str, value: float) -> None:
+        self._values[label] = float(value)
+
+    def get(self, label: str) -> float:
+        return self._values.get(label, 0.0)
+
+    def reset(self) -> None:
+        self._values.clear()
+
+
+# Collaboration metrics -------------------------------------------------------
+
+# Number of routed requests per collaboration mode.
+collab_routes = LabeledCounter(
+    "collab_routes_total", "Number of routed requests per collaboration mode."
+)
+
+# Number of prompts composed per collaboration mode.
+collab_prompts = LabeledCounter(
+    "collab_prompts_total", "Number of prompts composed per collaboration mode."
+)
+
+# Last requested collaboration depth per mode.
+collab_prompt_depth = LabeledGauge(
+    "collab_prompt_depth", "Last requested collaboration depth per mode."
+)
+
+# Server level metrics --------------------------------------------------------
+
+# Total orchestrate requests seen by the gateway server.
+orchestrate_requests = SimpleCounter(
+    "orchestrate_requests_total", "Total orchestrate requests processed."
+)
+
+# Number of telemetry events emitted by the gateway server.
+telemetry_events = SimpleCounter(
+    "telemetry_events_total", "Telemetry events emitted by the server."
+)

--- a/tests/telemetry/test_collab_metrics.py
+++ b/tests/telemetry/test_collab_metrics.py
@@ -1,0 +1,27 @@
+from router.collab_policy import CollaborationMode
+from router.router import Router
+from src.gateway.main import _telemetry_event
+from src.prompt.composer import add_collab_headers
+from src.telemetry import metrics
+
+
+def _reset_metrics() -> None:
+    metrics.collab_routes.reset()
+    metrics.collab_prompts.reset()
+    metrics.collab_prompt_depth.reset()
+    metrics.telemetry_events.reset()
+
+
+def test_collaboration_metrics_increment() -> None:
+    _reset_metrics()
+
+    router = Router(mode=CollaborationMode.COLLABORATE)
+    router.route(["a", "b"])
+    assert metrics.collab_routes.get("collaborate") == 1
+
+    add_collab_headers("hi", {"mode": "collaborate", "depth": 2})
+    assert metrics.collab_prompts.get("collaborate") == 1
+    assert metrics.collab_prompt_depth.get("collaborate") == 2
+
+    _telemetry_event()
+    assert metrics.telemetry_events.get() == 1


### PR DESCRIPTION
## Summary
- add simple Counter and Gauge classes for test-friendly metrics
- instrument router, prompt and gateway layers to emit collaboration metrics
- test that collaboration flow increments the appropriate counters and gauges

## Testing
- `pytest tests/telemetry/test_collab_metrics.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68c72fc949f4832ab78f3bb2f453146d