### PR TITLE
docs: add orchestrator collaboration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # NAESTRO — Orchestrator Platform
 
-[![CI][ci-badge]][ci]
-[![Release Please][rp-badge]][release-please]
+[![CI][ci-badge]][ci] [![Release Please][rp-badge]][release-please]
 [![Coverage][cov-badge]][codecov]
 
 [ci-badge]: https://github.com/cputer/naestro/actions/workflows/ci.yml/badge.svg?branch=main
@@ -46,6 +45,7 @@ research and code generation to SEO, Geo analytics, and multimodal interaction.
 - [Apple sidecars](docs/APPLE_MODELS.md)
 - [Integrations](docs/INTEGRATIONS.md)
 - [Graphiti Guide](docs/GRAPHITI.md)
+- [Orchestrator collaboration](docs/orchestrator_collaboration.md)
 - [Studio ↔ Core API contract](docs/UI_API_CONTRACT.md)
 - [VS Code Extension](docs/VS_CODE_EXTENSION.md)
 - [No-Replit deployment](docs/NO_REPLIT_DEPLOY.md)
@@ -239,4 +239,3 @@ MIT — see [License](LICENSE).
 ## Appendices / Key Integrations
 
 - **MetaCLIP2** — multilingual vision-text embeddings for cross-modal retrieval and grounding.
-

--- a/docs/orchestrator_collaboration.md
+++ b/docs/orchestrator_collaboration.md
@@ -1,8 +1,8 @@
 # Orchestrator Collaboration Modes & Depth
 
-Naestro's orchestrator supports several collaboration strategies when coordinating with
-online models. These preferences control how aggressively the system fans out work across
-models and how much autonomy the router has to escalate.
+Naestro's orchestrator supports several collaboration strategies when coordinating with online
+models. These preferences control how aggressively the system fans out work across models and how
+much autonomy the router has to escalate.
 
 ## Modes
 
@@ -18,20 +18,33 @@ Depth tunes the intensity of collaboration. `0` is minimal while `3` is exhausti
 
 ## Additional Flags
 
-- **auto** – allow the router to escalate mode/depth if confidence is low and
-  budget and latency caps permit.
+- **auto** – allow the router to escalate mode/depth if confidence is low and budget and latency
+  caps permit.
 - **ask_online** – when `false`, all cloud calls are blocked.
 - **budget_usd** – maximum spend for the run.
 - **p95_latency_s** – target 95th percentile latency.
 - **answer_strategy** – one of `self_if_confident`, `aggregate_always`,
   `ask_clarify_below_threshold` (requires `confidence_threshold`).
 
+## Example
+
+The preferences can be supplied when launching a run or in a job spec:
+
+```json
+{
+  "mode": "collaborate",
+  "depth": 2,
+  "auto": true,
+  "budget_usd": 0.5
+}
+```
+
 ## Telemetry
 
-Runs emit OpenTelemetry/Prometheus metrics prefixed with `orch.` capturing the selected
-mode, depth, auto flag, budgets, and whether an automatic escalation occurred.
+Runs emit OpenTelemetry/Prometheus metrics prefixed with `orch.` capturing the selected mode, depth,
+auto flag, budgets, and whether an automatic escalation occurred.
 
 ## References
 
-See [`ROADMAP.md`](./ROADMAP.md) for upcoming work integrating these preferences
-throughout the planner, router, prompt composer, and UI.
+See [`ROADMAP.md`](../ROADMAP.md) for upcoming work integrating these preferences throughout the
+planner, router, prompt composer, and UI.


### PR DESCRIPTION
## Summary
- document orchestrator collaboration modes, depth, flags, and example usage
- link collaboration guide from README and roadmap
- revert stray Naestro roadmap file edits

## Testing
- `npm test`
- `npx prettier docs/orchestrator_collaboration.md README.md ROADMAP.md --check` *(fails: Code style issues found in ROADMAP.md)*
- `npx markdownlint-cli2 docs/orchestrator_collaboration.md README.md ROADMAP.md`
- `npm run md:check` *(fails: Code style issues found in docs/Naestro_ROADMAP.md, REFERENCES.md, ROADMAP.md)*

------
https://chatgpt.com/codex/tasks/task_b_68c739dbbc5c832a9c081cb2fc6d1199