### PR TITLE
docs: add orchestrator collaboration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # NAESTRO — Orchestrator Platform
 
-[![CI][ci-badge]][ci]
-[![Release Please][rp-badge]][release-please]
+[![CI][ci-badge]][ci] [![Release Please][rp-badge]][release-please]
 [![Coverage][cov-badge]][codecov]
 
 [ci-badge]: https://github.com/cputer/naestro/actions/workflows/ci.yml/badge.svg?branch=main
@@ -46,6 +45,7 @@ research and code generation to SEO, Geo analytics, and multimodal interaction.
 - [Apple sidecars](docs/APPLE_MODELS.md)
 - [Integrations](docs/INTEGRATIONS.md)
 - [Graphiti Guide](docs/GRAPHITI.md)
+- [Orchestrator collaboration](docs/orchestrator_collaboration.md)
 - [Studio ↔ Core API contract](docs/UI_API_CONTRACT.md)
 - [VS Code Extension](docs/VS_CODE_EXTENSION.md)
 - [No-Replit deployment](docs/NO_REPLIT_DEPLOY.md)
@@ -239,4 +239,3 @@ MIT — see [License](LICENSE).
 ## Appendices / Key Integrations
 
 - **MetaCLIP2** — multilingual vision-text embeddings for cross-modal retrieval and grounding.
-

--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -45,7 +45,8 @@ docs. Keep it authoritative and in sync with `ROADMAP.md`.
 - **TensorRT Model Optimizer (NVIDIA)** — <https://github.com/NVIDIA/TensorRT-Model-Optimizer>
 - **LMCache** — <https://github.com/LMCache/LMCache>
 - **NIXL (KV / cache transfer)** — <https://github.com/ai-dynamo/nixl>
-- **NVIDIA DGX Spark (Workstation page)** — <https://www.nvidia.com/en-us/products/workstations/dgx-spark/>
+- **NVIDIA DGX Spark (Workstation page)** —
+  <https://www.nvidia.com/en-us/products/workstations/dgx-spark/>
 - **NVIDIA DGX Spark Datasheet (PDF)** —
   <https://nvdam.widen.net/s/tlzm8smqjx/workstation-datasheet-dgx-spark-gtc25-spring-nvidia-us-3716899-web>
 
@@ -66,16 +67,17 @@ docs. Keep it authoritative and in sync with `ROADMAP.md`.
 - **finllm-apps (cross-framework finance agents)** — <https://github.com/tinztwins/finllm-apps>
 - **Nebius UDR (Universal Deep Research prototype)** —
   <https://github.com/demianarc/nebiusaistudiodeepresearch>
-- **SFR-DeepResearch (self-factored retrieval)** —
-  <https://github.com/arekfu/sfr-deep-research>
+- **SFR-DeepResearch (self-factored retrieval)** — <https://github.com/arekfu/sfr-deep-research>
 - **Awesome-Nano-Banana-images (edge/device OS images; reference-only)** —
   <https://github.com/PicoTrex/Awesome-Nano-Banana-images>
 
 ## Vision / Multimodal
 
-- **MetaCLIP2 (multilingual vision-text embeddings)** — <https://huggingface.co/docs/transformers/model_doc/metaclip2>
+- **MetaCLIP2 (multilingual vision-text embeddings)** —
+  <https://huggingface.co/docs/transformers/model_doc/metaclip2>
 - **Transformers (integration docs)** — <https://huggingface.co/docs/transformers/index>
-- **Text↔Image search notebook (example)** — <https://github.com/huggingface/notebooks/blob/main/examples/image_similarity.ipynb>
+- **Text↔Image search notebook (example)** —
+  <https://github.com/huggingface/notebooks/blob/main/examples/image_similarity.ipynb>
 
 ## Voice / Speech
 
@@ -127,7 +129,8 @@ docs. Keep it authoritative and in sync with `ROADMAP.md`.
 ## Tooling / Connectors / Protocols
 
 - **Model Context Protocol (MCP)** — <https://modelcontextprotocol.io/>
-- **OpenAI adds powerful but dangerous support for MCP in ChatGPT Dev Mode (VentureBeat)** — _link unavailable_
+- **OpenAI adds powerful but dangerous support for MCP in ChatGPT Dev Mode (VentureBeat)** — _link
+  unavailable_
 - **Zapier Platform** — <https://platform.zapier.com/>
 - **Jira Cloud Platform** — <https://developer.atlassian.com/cloud/jira/platform/>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -101,8 +101,8 @@ through AnyLLM (plus official SDKs). Safety via NeMo Guardrails / Guardrails AI.
   metrics. Selects optimal chunking strategy dynamically.
 - **PO Policy Module** — Preference optimization suite (PVPO/DCPO/…); stability/effectiveness
   monitors.
-- **Collaboration Modes & Depth** — Per-run preferences for orchestrator collaboration with
-  auto escalation, budgets, and answer strategies. See
+- **Collaboration Modes & Depth** — Per-run preferences for orchestrator collaboration with auto
+  escalation, budgets, and answer strategies. See
   [docs/orchestrator_collaboration.md](docs/orchestrator_collaboration.md).
 - **Runtime Adapters** — LangGraph/CrewAI/AgentScope/AutoGen/Agent Squad/Semantic Kernel/SuperAGI
   with policy/trace parity.
@@ -416,12 +416,13 @@ constitutional bypass.
 - PDF/OCR (PyMuPDF/Tesseract)
 - Playwright browser agent
 - Fusion Controller (multimodal I/O)
-- **MetaCLIP2** embedding service + vector index; image region extraction (saliency or OCR blocks); Studio preview for visual citations.
-  **Exit Criteria:**
+- **MetaCLIP2** embedding service + vector index; image region extraction (saliency or OCR blocks);
+  Studio preview for visual citations. **Exit Criteria:**
 - Voice roundtrip working
 - PDF → structured JSON
 - Browser agent completes form
-- Cross-modal search demo (“find the whiteboard with graph about revenue”); answer includes **image region citation** and supporting text.
+- Cross-modal search demo (“find the whiteboard with graph about revenue”); answer includes **image
+  region citation** and supporting text.
 
 ---
 
@@ -784,13 +785,17 @@ Every LLM span must include:
 - Federated task delegation between orgs.
 - Marketplace rentals of expert agents.
 - Strategic dialogues for corporate planning.
-- **Cross-modal incident triage** — search logs + screenshots ("error dialog about OAuth on staging") with visual box citation.
-- **Docs & diagrams** — retrieve architecture diagram segments that support a claim and cite the exact region.
+- **Cross-modal incident triage** — search logs + screenshots ("error dialog about OAuth on
+  staging") with visual box citation.
+- **Docs & diagrams** — retrieve architecture diagram segments that support a claim and cite the
+  exact region.
 
 ## 13) Risks & Mitigations
 
-- **Visual hallucinations / weak grounding** → require region-level evidence with IoU≥τ and cosine similarity≥σ; block delivery if evaluator fails; fall back to text-only RAG.
-- **Storage growth** → thumbnail + region-crop tiering; TTL for rarely accessed artifacts; object-store lifecycle rules.
+- **Visual hallucinations / weak grounding** → require region-level evidence with IoU≥τ and cosine
+  similarity≥σ; block delivery if evaluator fails; fall back to text-only RAG.
+- **Storage growth** → thumbnail + region-crop tiering; TTL for rarely accessed artifacts;
+  object-store lifecycle rules.
 
 ---
 

--- a/docs/Naestro_ROADMAP.md
+++ b/docs/Naestro_ROADMAP.md
@@ -737,12 +737,16 @@ Every LLM span must include:
 - Federated task delegation between orgs.
 - Marketplace rentals of expert agents.
 - Strategic dialogues for corporate planning.
-- **Cross-modal incident triage** — search logs + screenshots ("error dialog about OAuth on staging") with visual box citation.
-- **Docs & diagrams** — retrieve architecture diagram segments that support a claim and cite the exact region.
+- **Cross-modal incident triage** — search logs + screenshots ("error dialog about OAuth on
+  staging") with visual box citation.
+- **Docs & diagrams** — retrieve architecture diagram segments that support a claim and cite the
+  exact region.
 
 ## 13) Risks & Mitigations
 
-- **Visual hallucinations / weak grounding** → require region-level evidence with IoU≥τ and cosine similarity≥σ; block delivery if evaluator fails; fall back to text-only RAG.
-- **Storage growth** → thumbnail + region-crop tiering; TTL for rarely accessed artifacts; object-store lifecycle rules.
+- **Visual hallucinations / weak grounding** → require region-level evidence with IoU≥τ and cosine
+  similarity≥σ; block delivery if evaluator fails; fall back to text-only RAG.
+- **Storage growth** → thumbnail + region-crop tiering; TTL for rarely accessed artifacts;
+  object-store lifecycle rules.
 
 ---

--- a/docs/orchestrator_collaboration.md
+++ b/docs/orchestrator_collaboration.md
@@ -1,8 +1,8 @@
 # Orchestrator Collaboration Modes & Depth
 
-Naestro's orchestrator supports several collaboration strategies when coordinating with
-online models. These preferences control how aggressively the system fans out work across
-models and how much autonomy the router has to escalate.
+Naestro's orchestrator supports several collaboration strategies when coordinating with online
+models. These preferences control how aggressively the system fans out work across models and how
+much autonomy the router has to escalate.
 
 ## Modes
 
@@ -18,20 +18,33 @@ Depth tunes the intensity of collaboration. `0` is minimal while `3` is exhausti
 
 ## Additional Flags
 
-- **auto** – allow the router to escalate mode/depth if confidence is low and
-  budget and latency caps permit.
+- **auto** – allow the router to escalate mode/depth if confidence is low and budget and latency
+  caps permit.
 - **ask_online** – when `false`, all cloud calls are blocked.
 - **budget_usd** – maximum spend for the run.
 - **p95_latency_s** – target 95th percentile latency.
 - **answer_strategy** – one of `self_if_confident`, `aggregate_always`,
   `ask_clarify_below_threshold` (requires `confidence_threshold`).
 
+## Example
+
+The preferences can be supplied when launching a run or in a job spec:
+
+```json
+{
+  "mode": "collaborate",
+  "depth": 2,
+  "auto": true,
+  "budget_usd": 0.5
+}
+```
+
 ## Telemetry
 
-Runs emit OpenTelemetry/Prometheus metrics prefixed with `orch.` capturing the selected
-mode, depth, auto flag, budgets, and whether an automatic escalation occurred.
+Runs emit OpenTelemetry/Prometheus metrics prefixed with `orch.` capturing the selected mode, depth,
+auto flag, budgets, and whether an automatic escalation occurred.
 
 ## References
 
-See [`ROADMAP.md`](./ROADMAP.md) for upcoming work integrating these preferences
-throughout the planner, router, prompt composer, and UI.
+See [`ROADMAP.md`](../ROADMAP.md) for upcoming work integrating these preferences throughout the
+planner, router, prompt composer, and UI.


### PR DESCRIPTION
## Summary
- document orchestrator collaboration modes, depth, flags, and example usage
- link collaboration guide from README and roadmap
- format roadmap and references to satisfy markdown style checks

## Testing
- `npm test`
- `npx prettier docs/orchestrator_collaboration.md README.md ROADMAP.md docs/Naestro_ROADMAP.md REFERENCES.md --check`
- `npm run md:check`


------
https://chatgpt.com/codex/tasks/task_b_68c739dbbc5c832a9c081cb2fc6d1199