### PR TITLE
docs: reconcile roadmap conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@
 **Production-grade LLM orchestrator** with LangGraph-style workflow execution, pgvector-backed RAG,
 secure sandboxing, and multi-model routing (NIM / vLLM / SLM).
 
-Naestro is an AI Orchestrator for multi-model collaboration.
+Naestro is an AI Orchestrator for multi-model collaboration. Review the
+[orchestrator collaboration guide](docs/orchestrator_collaboration.md) for collaboration modes and
+depth.
 
 📖 Read the [Whitepaper](./WHITEPAPER.md)  
 ➡️ See the [Roadmap](./ROADMAP.md) 🌌 Explore the [Vision](./VISION.md)

--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -1,7 +1,8 @@
 # REFERENCES
 
 This file centralizes all links to external resources referenced in the Naestro roadmap and related
-docs. Keep it authoritative and in sync with `ROADMAP.md`.
+docs. Keep it authoritative and in sync with `ROADMAP.md`. For collaboration modes, consult the
+[orchestrator collaboration guide](docs/orchestrator_collaboration.md).
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -102,8 +102,8 @@ through AnyLLM (plus official SDKs). Safety via NeMo Guardrails / Guardrails AI.
 - **PO Policy Module** — Preference optimization suite (PVPO/DCPO/…); stability/effectiveness
   monitors.
 - **Collaboration Modes & Depth** — Per-run preferences for orchestrator collaboration with auto
-  escalation, budgets, and answer strategies. See
-  [docs/orchestrator_collaboration.md](docs/orchestrator_collaboration.md).
+  escalation, budgets, and answer strategies (see
+  [docs/orchestrator_collaboration.md](docs/orchestrator_collaboration.md) for details).
 - **Runtime Adapters** — LangGraph/CrewAI/AgentScope/AutoGen/Agent Squad/Semantic Kernel/SuperAGI
   with policy/trace parity.
 - **Tokenomics Engine** — Credits/budgets; marketplace transactions.

--- a/docs/orchestrator_collaboration.md
+++ b/docs/orchestrator_collaboration.md
@@ -47,4 +47,5 @@ auto flag, budgets, and whether an automatic escalation occurred.
 ## References
 
 See [`ROADMAP.md`](../ROADMAP.md) for upcoming work integrating these preferences throughout the
-planner, router, prompt composer, and UI.
+planner, router, prompt composer, and UI. Related external links are listed in
+[REFERENCES.md](../REFERENCES.md).


### PR DESCRIPTION
## Summary
- reference the orchestrator collaboration guide in README, ROADMAP, and references
- mention where to find external collaboration links

## Testing
- `npm run md:check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68c73fe7ee24832ab673d9ce4e1eb5ef