### PR TITLE
chore: link check workflow

### DIFF
--- a/.github/workflows/reference-link-check.yml
+++ b/.github/workflows/reference-link-check.yml
@@ -4,6 +4,7 @@ on:
     paths:
       - "docs/**/*.md"
       - "REFERENCES.md"
+      - "ROADMAP.md"
   workflow_dispatch: {}
 permissions:
   contents: read
@@ -16,15 +17,15 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22
-      - name: Install markdown-link-check
-        run: npm i -g markdown-link-check@3
-      - name: Check links in docs
+      - name: Install dependencies
+        run: npm ci
+      - name: Check links
         run: |
           set -euo pipefail
-          files="$(git ls-files 'docs/**/*.md' 'REFERENCES.md')"
+          files="$(git ls-files 'docs/**/*.md' 'REFERENCES.md' 'ROADMAP.md')"
           echo "$files" | tr ' ' '\n' | while read -r f; do
             echo "🔗 Checking $f"
-            markdown-link-check -q -c .mlc.config.json "$f"
+            npx markdown-link-check -q -c .mlc.config.json "$f"
           done
       - name: Upload summary
         if: always()

--- a/.mlc.config.json
+++ b/.mlc.config.json
@@ -1,11 +1,12 @@
 {
   "retryOn429": true,
-  "retryCount": 3,
+  "retryCount": 5,
   "timeout": "20s",
   "aliveStatusCodes": [200, 206, 301, 302, 308],
   "ignorePatterns": [
     { "pattern": "^mailto:" },
     { "pattern": "localhost(:\\d+)?" },
-    { "pattern": "bailian.console.alibabacloud.com/.+#/doc/" }
+    { "pattern": "bailian.console.alibabacloud.com/.+#/doc/" },
+    { "pattern": "^https://github.com/.+#L\\d+$" }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # NAESTRO — Orchestrator Platform
 
-[![CI][ci-badge]][ci] [![Release Please][rp-badge]][release-please]
+[![CI][ci-badge]][ci] [![Release Please][rp-badge]][release-please] [![Reference Links][ref-badge]][ref]
 [![Coverage][cov-badge]][codecov]
 
 [ci-badge]: https://github.com/cputer/naestro/actions/workflows/ci.yml/badge.svg?branch=main
 [ci]: https://github.com/cputer/naestro/actions/workflows/ci.yml
 [rp-badge]: https://github.com/cputer/naestro/actions/workflows/release-please.yml/badge.svg
 [release-please]: https://github.com/cputer/naestro/actions/workflows/release-please.yml
+[ref-badge]: https://github.com/cputer/naestro/actions/workflows/reference-link-check.yml/badge.svg?branch=main
+[ref]: https://github.com/cputer/naestro/actions/workflows/reference-link-check.yml
 [cov-badge]: https://codecov.io/gh/cputer/naestro/branch/main/graph/badge.svg
 [codecov]: https://codecov.io/gh/cputer/naestro
 


### PR DESCRIPTION
## Summary
- add README badge for reference link checks
- run markdown-link-check across docs, roadmap, and references via workflow
- configure retries and ignore patterns for link checker

## Testing
- `npm test`
- `npm run markdown-link-check`

------
https://chatgpt.com/codex/tasks/task_b_68c747d91b4c832a961c0b776bd9e65d