### PR TITLE
Add coverage tests for core modules and UI collaboration panel

### DIFF
--- a/src/prompt/composer.py
+++ b/src/prompt/composer.py
@@ -72,12 +72,12 @@ def choose_answer(responses: List[Mapping[str, Any]], prefs: Mapping[str, Any]) 
     answer is selected.
     """
 
+    if not responses:
+        return ""
+
     cfg = clamp_prefs(dict(prefs))
     strat = cfg["answer_strategy"]
     threshold = float(cfg["confidence_threshold"])
-
-    if not responses:
-        return ""
 
     top = responses[0]
     top_conf = float(top.get("confidence", 0.0))

--- a/tests/planner/test_pref_defaults.py
+++ b/tests/planner/test_pref_defaults.py
@@ -1,0 +1,11 @@
+from orchestrator.planner import DEFAULT_COLLAB_PREFS, clamp_prefs
+
+
+def test_clamp_prefs_applies_defaults():
+    prefs = {"mode": "solo"}
+    clamped = clamp_prefs(prefs)
+    for key, value in DEFAULT_COLLAB_PREFS.items():
+        if key == "mode":
+            assert clamped[key] == "solo"
+        else:
+            assert clamped[key] == value

--- a/tests/prompt/test_composer_metrics.py
+++ b/tests/prompt/test_composer_metrics.py
@@ -1,0 +1,37 @@
+from src.prompt.composer import add_collab_headers, choose_answer
+from src.telemetry import metrics
+
+
+def test_add_collab_headers_records_metrics():
+    metrics.collab_prompts.reset()
+    metrics.collab_prompt_depth.reset()
+    add_collab_headers("hi", {"mode": "consult", "depth": 2})
+    assert metrics.collab_prompts.get("consult") == 1
+    assert metrics.collab_prompt_depth.get("consult") == 2
+
+
+def test_choose_answer_empty_responses_returns_blank(monkeypatch):
+    called = False
+
+    def fake(p):
+        nonlocal called
+        called = True
+        return p
+
+    monkeypatch.setattr("src.prompt.composer.clamp_prefs", fake)
+    assert choose_answer([], {}) == ""
+    assert called is False
+
+
+def test_choose_answer_unknown_strategy_aggregates():
+    responses = [{"content": "A", "confidence": 0.1}]
+    assert choose_answer(responses, {"answer_strategy": "mystery"}) == "A"
+
+
+def test_choose_answer_fallback(monkeypatch):
+    responses = [{"content": "A"}]
+    monkeypatch.setattr(
+        "src.prompt.composer.clamp_prefs", lambda p: p  # bypass clamping
+    )
+    prefs = {"answer_strategy": "unknown", "confidence_threshold": 0.0}
+    assert choose_answer(responses, prefs) == "A"

--- a/tests/router/test_metrics_increment.py
+++ b/tests/router/test_metrics_increment.py
@@ -1,0 +1,10 @@
+from router.collab_policy import CollaborationMode
+from router.router import Router
+from src.telemetry import metrics
+
+
+def test_router_records_metric():
+    metrics.collab_routes.reset()
+    router = Router(CollaborationMode.CONSULT)
+    router.route(["a", "b"])
+    assert metrics.collab_routes.get("consult") == 1

--- a/tests/server/test_gateway_metrics.py
+++ b/tests/server/test_gateway_metrics.py
@@ -1,0 +1,39 @@
+from fastapi.testclient import TestClient
+
+import src.gateway.main as gw
+from src.gateway.main import app
+
+
+def test_orchestrate_increments_metric(monkeypatch):
+    class DummyResponse:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"ok": True}
+
+    class DummyAsyncClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+        async def post(self, url, json):
+            return DummyResponse()
+
+    gw.orchestrate_requests.reset()
+    monkeypatch.setattr(gw.httpx, "AsyncClient", DummyAsyncClient)
+    client = TestClient(app)
+    resp = client.post("/orchestrate", json={"task": "demo"})
+    assert resp.status_code == 200
+    assert gw.orchestrate_requests.get() == 1
+
+
+def test_telemetry_event_increments_metric():
+    gw.telemetry_events.reset()
+    gw._telemetry_event()
+    assert gw.telemetry_events.get() == 1

--- a/tests/telemetry/test_metric_classes.py
+++ b/tests/telemetry/test_metric_classes.py
@@ -1,0 +1,21 @@
+from src.telemetry.metrics import LabeledCounter, LabeledGauge, SimpleCounter
+
+
+def test_counter_and_gauge_reset():
+    lc = LabeledCounter("c", "d")
+    lc.inc("x")
+    assert lc.get("x") == 1
+    lc.reset()
+    assert lc.get("x") == 0
+
+    sc = SimpleCounter("s", "d")
+    sc.inc()
+    assert sc.get() == 1
+    sc.reset()
+    assert sc.get() == 0
+
+    lg = LabeledGauge("g", "d")
+    lg.set("x", 1.5)
+    assert lg.get("x") == 1.5
+    lg.reset()
+    assert lg.get("x") == 0.0

--- a/ui/tests/CollaborationPanelStatus.test.tsx
+++ b/ui/tests/CollaborationPanelStatus.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import React from 'react'
+import CollaborationPanel from '../components/CollaborationPanel'
+
+describe('CollaborationPanel status handling', () => {
+  it('shows error when load fails', async () => {
+    const loadPrefs = vi.fn().mockRejectedValue(new Error('fail'))
+    render(<CollaborationPanel loadPrefs={loadPrefs} />)
+    expect(await screen.findByRole('alert')).toHaveTextContent(/error/i)
+  })
+
+  it('displays saved status after successful save', async () => {
+    const loadPrefs = vi.fn().mockResolvedValue({ mode: 'solo' })
+    const savePrefs = vi.fn().mockResolvedValue({})
+    render(<CollaborationPanel loadPrefs={loadPrefs} savePrefs={savePrefs} />)
+    await screen.findByDisplayValue('solo')
+    fireEvent.click(screen.getByRole('button', { name: /save/i }))
+    expect(await screen.findByRole('status')).toHaveTextContent(/saved/i)
+  })
+})


### PR DESCRIPTION
## Summary
- add pytest suites covering server metrics, planner defaults, router telemetry, composer edge cases, and telemetry helpers
- add vitest suite verifying CollaborationPanel status and error handling
- avoid clamping preferences when no responses are provided and test early return behavior

## Testing
- `pytest --maxfail=1 --cov=src`
- `cd ui && npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_b_68c749316860832a8d5acd27fb9b9eeb