### PR TITLE
Avoid clamping on empty response lists

### DIFF
--- a/src/prompt/composer.py
+++ b/src/prompt/composer.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 from typing import Any, Dict, Iterable, List, Mapping
 
 from orchestrator.planner import clamp_prefs
-from src.telemetry.metrics import collab_prompts, collab_prompt_depth, pref_clamps
+from src.telemetry.metrics import collab_prompt_depth, collab_prompts, pref_clamps
 
 
 def _aggregate(responses: Iterable[Mapping[str, Any]]) -> str:
@@ -72,12 +72,12 @@ def choose_answer(responses: List[Mapping[str, Any]], prefs: Mapping[str, Any]) 
     answer is selected.
     """
 
+    if not responses:
+        return ""
+
     cfg = clamp_prefs(dict(prefs))
     strat = cfg["answer_strategy"]
     threshold = float(cfg["confidence_threshold"])
-
-    if not responses:
-        return ""
 
     top = responses[0]
     top_conf = float(top.get("confidence", 0.0))
@@ -99,9 +99,7 @@ def choose_answer(responses: List[Mapping[str, Any]], prefs: Mapping[str, Any]) 
     return _aggregate(responses)
 
 
-def answer_stream(
-    responses: Iterable[Mapping[str, Any]], prefs: Mapping[str, Any]
-):
+def answer_stream(responses: Iterable[Mapping[str, Any]], prefs: Mapping[str, Any]):
     """Yield a final answer for ``responses`` based on ``prefs``.
 
     The current implementation is intentionally lightweight: it yields a single

--- a/tests/prompt/test_composer_metrics.py
+++ b/tests/prompt/test_composer_metrics.py
@@ -1,4 +1,11 @@
-from src.prompt.composer import add_collab_headers, choose_answer, answer_stream, add_pref_clamp
+from unittest.mock import MagicMock
+
+from src.prompt.composer import (
+    add_collab_headers,
+    add_pref_clamp,
+    answer_stream,
+    choose_answer,
+)
 from src.telemetry import metrics
 
 
@@ -10,8 +17,11 @@ def test_add_collab_headers_records_metrics():
     assert metrics.collab_prompt_depth.get("consult") == 2
 
 
-def test_choose_answer_empty_responses_returns_blank():
+def test_choose_answer_empty_responses_returns_blank(monkeypatch):
+    mock = MagicMock(return_value={})
+    monkeypatch.setattr("src.prompt.composer.clamp_prefs", mock)
     assert choose_answer([], {}) == ""
+    mock.assert_not_called()
 
 
 def test_choose_answer_unknown_strategy_aggregates():


### PR DESCRIPTION
## Summary
- avoid clamping prefs when choose_answer receives no responses
- ensure empty response test verifies clamp_prefs is not called

## Testing
- `pre-commit run --files src/prompt/composer.py tests/prompt/test_composer_metrics.py`
- `pytest tests/prompt/test_composer_metrics.py`


------
https://chatgpt.com/codex/tasks/task_b_68c755412340832a95840a2b4fef2ca8