### PR TITLE
chore: use npm install for reference link check

### DIFF
--- a/.github/workflows/reference-link-check.yml
+++ b/.github/workflows/reference-link-check.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           node-version: 22
       - name: Install dependencies
-        run: npm ci
+        run: npm install --no-audit --no-fund
       - name: Check links
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary
- ensure reference link check workflow installs dependencies without package-lock by using npm install

## Testing
- `pre-commit run --files .github/workflows/reference-link-check.yml`

------
https://chatgpt.com/codex/tasks/task_b_68c7596adc30832aac92430fe40e3e21