### PR TITLE
chore: use pnpm install in ui Dockerfile

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,9 +57,9 @@ system Node enabled.
 
 Run these commands locally to mirror the CI jobs:
 
-- **UI smoke**: `npm ci -C ui && npm run test:smoke -C ui`
+- **UI smoke**: `pnpm install --frozen-lockfile -C ui && pnpm run test:smoke -C ui`
 - **Python smoke**: `pytest -q -k "health or smoke"`
-- **UI full**: `npm ci -C ui && CI=true npm run test:ci -C ui`
+- **UI full**: `pnpm install --frozen-lockfile -C ui && CI=true pnpm run test:ci -C ui`
 - **Python full**:
   `pytest -m "not slow" --maxfail=1 -q --durations=10 --cov=src --cov-report=xml --cov-fail-under=100`
 

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -4,12 +4,12 @@ FROM node:22.12-alpine AS build
 WORKDIR /app
 
 # Install dependencies
-COPY package*.json ./
-RUN npm ci
+COPY package.json pnpm-lock.yaml ./
+RUN corepack enable && pnpm install --frozen-lockfile
 
 # Copy source and build
 COPY . .
-RUN npm run build
+RUN pnpm run build
 
 # Stage 2: production with Nginx
 FROM nginx:1.27-alpine


### PR DESCRIPTION
## Summary
- build UI with pnpm and a frozen lockfile
- document pnpm install for UI smoke/full tests

## Testing
- `pre-commit run --files ui/Dockerfile CONTRIBUTING.md`
- `pnpm test:ci`

------
https://chatgpt.com/codex/tasks/task_b_68c75d26524c832a89243c2f083fd99a