### PR TITLE
docs: clarify phase D TTS options

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -413,6 +413,8 @@ constitutional bypass.
 **Deliverables:**
 
 - ASR/TTS (Parlant/VibeVoice/DIA)
+  - SV2TTS / Real-Time Voice Cloning is prototype-only and not suitable for production.
+  - Preferred production TTS: NVIDIA Riva, Coqui XTTS v2, Piper, ElevenLabs, PlayHT, Azure TTS, Google TTS, Amazon Polly.
 - PDF/OCR (PyMuPDF/Tesseract)
 - Playwright browser agent
 - Fusion Controller (multimodal I/O)


### PR DESCRIPTION
## Summary
- Note that SV2TTS / Real-Time Voice Cloning is prototype-only and not production-ready
- Recommend production-ready TTS engines like NVIDIA Riva, Coqui XTTS v2, Piper, ElevenLabs, PlayHT, Azure TTS, Google TTS, and Amazon Polly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68c782fc1620832a851a665e25924b6d