### PR TITLE
feat: add generic TTS adapters

### DIFF
--- a/registry/tools.json
+++ b/registry/tools.json
@@ -8,5 +8,20 @@
       },
       "required": ["url"]
     }
+  },
+  "tts:synthesize": {
+    "description": "Synthesize speech using a configured TTS provider",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "text": { "type": "string" },
+        "provider": { "type": "string" },
+        "voice": { "type": "string" },
+        "style": { "type": "string" },
+        "stream": { "type": "boolean", "default": true },
+        "endpoint": { "type": "string" }
+      },
+      "required": ["text", "provider", "voice"]
+    }
   }
 }

--- a/src/tts.py
+++ b/src/tts.py
@@ -1,0 +1,35 @@
+"""Common text-to-speech interface."""
+
+from __future__ import annotations
+
+import os
+from typing import Callable, Iterable
+
+from .tts_azure import synthesize as azure_synthesize
+from .tts_elevenlabs import synthesize as elevenlabs_synthesize
+from .tts_piper import synthesize as piper_synthesize
+from .tts_playht import synthesize as playht_synthesize
+from .tts_riva import synthesize as riva_synthesize
+
+_TTS_PROVIDERS: dict[
+    str, Callable[[str, str, str | None, bool], Iterable[bytes] | bytes]
+] = {
+    "riva": riva_synthesize,
+    "elevenlabs": elevenlabs_synthesize,
+    "azure": azure_synthesize,
+    "playht": playht_synthesize,
+    "piper": piper_synthesize,
+}
+
+
+def synthesize(text: str, voice: str, style: str | None, stream: bool = True):
+    """Synthesize speech using the provider defined by ``TTS_PROVIDER``.
+
+    The provider name is read from the ``TTS_PROVIDER`` environment variable and
+    defaults to ``"riva"``.
+    """
+    provider = os.getenv("TTS_PROVIDER", "riva").lower()
+    synth = _TTS_PROVIDERS.get(provider)
+    if synth is None:
+        raise ValueError(f"Unsupported TTS provider: {provider}")
+    return synth(text=text, voice=voice, style=style, stream=stream)

--- a/src/tts_azure.py
+++ b/src/tts_azure.py
@@ -1,0 +1,8 @@
+"""Stub adapter for Azure text-to-speech."""
+
+from __future__ import annotations
+
+
+def synthesize(text: str, voice: str, style: str | None, stream: bool = True):
+    """Placeholder Azure TTS implementation."""
+    raise NotImplementedError("Azure TTS adapter not implemented")

--- a/src/tts_elevenlabs.py
+++ b/src/tts_elevenlabs.py
@@ -1,0 +1,40 @@
+"""Adapter for ElevenLabs text-to-speech."""
+
+from __future__ import annotations
+
+import os
+from typing import Iterable
+
+import requests
+
+
+def synthesize(
+    text: str, voice: str, style: str | None, stream: bool = True
+) -> Iterable[bytes] | bytes:
+    """Synthesize ``text`` into speech using ElevenLabs.
+
+    The adapter is guarded by the ``ENABLE_ELEVENLABS`` feature flag. Set
+    ``ELEVENLABS_API_KEY`` to the API key.
+    """
+    if not os.getenv("ENABLE_ELEVENLABS"):
+        raise RuntimeError("ElevenLabs TTS is disabled")
+
+    api_key = os.getenv("ELEVENLABS_API_KEY")
+    if not api_key:
+        raise RuntimeError("ELEVENLABS_API_KEY is not set")
+
+    url = f"https://api.elevenlabs.io/v1/text-to-speech/{voice}"
+    headers = {"xi-api-key": api_key}
+    payload: dict[str, object] = {"text": text}
+    if style:
+        payload["voice_settings"] = {"style": style}
+
+    response = requests.post(url, headers=headers, json=payload, stream=stream)
+    response.raise_for_status()
+
+    if stream:
+        for chunk in response.iter_content(chunk_size=None):
+            if chunk:
+                yield chunk
+    else:
+        return response.content

--- a/src/tts_piper.py
+++ b/src/tts_piper.py
@@ -1,0 +1,8 @@
+"""Stub adapter for Piper text-to-speech."""
+
+from __future__ import annotations
+
+
+def synthesize(text: str, voice: str, style: str | None, stream: bool = True):
+    """Placeholder Piper TTS implementation."""
+    raise NotImplementedError("Piper TTS adapter not implemented")

--- a/src/tts_playht.py
+++ b/src/tts_playht.py
@@ -1,0 +1,8 @@
+"""Stub adapter for PlayHT text-to-speech."""
+
+from __future__ import annotations
+
+
+def synthesize(text: str, voice: str, style: str | None, stream: bool = True):
+    """Placeholder PlayHT TTS implementation."""
+    raise NotImplementedError("PlayHT TTS adapter not implemented")

--- a/src/tts_riva.py
+++ b/src/tts_riva.py
@@ -1,0 +1,40 @@
+"""Adapter for NVIDIA Riva text-to-speech."""
+
+from __future__ import annotations
+
+import os
+from typing import Iterable
+
+try:
+    from riva.client import Auth, SpeechSynthesisClient
+except Exception:  # pragma: no cover - optional dependency
+    Auth = None
+    SpeechSynthesisClient = None
+
+
+def synthesize(
+    text: str, voice: str, style: str | None, stream: bool = True
+) -> Iterable[bytes] | bytes:
+    """Synthesize ``text`` into speech using Riva.
+
+    Args:
+        text: The text to convert.
+        voice: Voice name to use.
+        style: Optional speaking style.
+        stream: When ``True`` yield audio chunks, otherwise return full audio bytes.
+    """
+    if SpeechSynthesisClient is None or Auth is None:
+        raise RuntimeError("riva.client is required for Riva TTS")
+
+    server = os.getenv("RIVA_TTS_URL", "localhost:50051")
+    auth = Auth(server)
+    client = SpeechSynthesisClient(server, auth=auth, use_ssl=False)
+
+    if stream:
+        for response in client.synthesize_streaming(
+            text, voice_name=voice, speaking_style=style
+        ):
+            yield response.audio
+    else:
+        resp = client.synthesize(text, voice_name=voice, speaking_style=style)
+        return resp.audio


### PR DESCRIPTION
## Summary
- add generic TTS tool schema supporting provider, voice, style, stream, endpoint
- implement Riva and ElevenLabs TTS adapters with common interface
- add stubs for Azure, PlayHT, and Piper

## Testing
- `pre-commit run --files registry/tools.json src/tts_riva.py src/tts_elevenlabs.py src/tts_azure.py src/tts_playht.py src/tts_piper.py src/tts.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68c7836f49f8832a96f47831ae1bc130