### PR TITLE
feat(voice): add TTS interface + stubs and streaming/SSML tests

### DIFF
--- a/src/voice/__init__.py
+++ b/src/voice/__init__.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from .adapters.tts_null import NullTTSAdapter
+from .adapters.tts_piper_stub import PiperTTSStub
+from .tts import BaseTTSAdapter, TTSChunk, TTSRequest, parse_ssml
+
+__all__ = [
+    "TTSRequest",
+    "TTSChunk",
+    "BaseTTSAdapter",
+    "parse_ssml",
+    "NullTTSAdapter",
+    "PiperTTSStub",
+]

--- a/src/voice/adapters/__init__.py
+++ b/src/voice/adapters/__init__.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+from .tts_null import NullTTSAdapter
+from .tts_piper_stub import PiperTTSStub
+
+__all__ = ["NullTTSAdapter", "PiperTTSStub"]

--- a/src/voice/adapters/tts_null.py
+++ b/src/voice/adapters/tts_null.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from typing import Iterable
+
+from ..tts import BaseTTSAdapter, TTSChunk, TTSRequest, parse_ssml
+
+
+class NullTTSAdapter(BaseTTSAdapter):
+    def supports_ssml(self) -> bool:
+        return True
+
+    def synthesize_stream(self, req: TTSRequest) -> Iterable[TTSChunk]:
+        text = req.text
+        if req.ssml:
+            text, _ = parse_ssml(text)
+        data = text.encode()
+        num_chunks = min(5, max(3, (len(data) + 99) // 100))
+        chunk_size = max(1, (len(data) + num_chunks - 1) // num_chunks)
+        seq = 0
+        for i in range(0, len(data), chunk_size):
+            end = i + chunk_size
+            final = end >= len(data)
+            yield TTSChunk(data=data[i:end], seq=seq, final=final)
+            seq += 1

--- a/src/voice/adapters/tts_piper_stub.py
+++ b/src/voice/adapters/tts_piper_stub.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from typing import Iterable
+
+from ..tts import BaseTTSAdapter, TTSChunk, TTSRequest
+
+
+class PiperTTSStub(BaseTTSAdapter):
+    def supports_ssml(self) -> bool:
+        return False
+
+    def synthesize_stream(self, req: TTSRequest) -> Iterable[TTSChunk]:
+        data = req.text.encode()
+        num_chunks = min(5, max(3, (len(data) + 99) // 100))
+        chunk_size = max(1, (len(data) + num_chunks - 1) // num_chunks)
+        seq = 0
+        for i in range(0, len(data), chunk_size):
+            end = i + chunk_size
+            final = end >= len(data)
+            yield TTSChunk(data=data[i:end], seq=seq, final=final)
+            seq += 1

--- a/src/voice/tts.py
+++ b/src/voice/tts.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, Tuple
+from xml.etree import ElementTree as ET
+
+
+@dataclass
+class TTSRequest:
+    text: str
+    voice: str | None = None
+    style: str | None = None
+    ssml: bool = False
+
+
+@dataclass
+class TTSChunk:
+    data: bytes
+    seq: int
+    final: bool
+
+
+class BaseTTSAdapter(ABC):
+    @abstractmethod
+    def synthesize_stream(self, req: TTSRequest) -> Iterable[TTSChunk]:
+        ...
+
+    @abstractmethod
+    def supports_ssml(self) -> bool:
+        ...
+
+
+def parse_ssml(text: str) -> Tuple[str, Dict[str, Any]]:
+    """Parse minimal SSML and return plain text and extracted controls.
+
+    Recognizes ``<prosody rate>``, ``<emphasis level>`` and ``<break time>``.
+    Unknown tags are ignored. Returns the text content with tags removed and a
+    dictionary of parsed controls.
+    """
+    controls: Dict[str, Any] = {}
+    try:
+        root = ET.fromstring(f"<root>{text}</root>")
+    except ET.ParseError:
+        return text, controls
+
+    parts: list[str] = []
+    for elem in root.iter():
+        if elem.tag == "prosody":
+            rate = elem.attrib.get("rate")
+            if rate:
+                controls["prosody.rate"] = rate
+        elif elem.tag == "emphasis":
+            level = elem.attrib.get("level")
+            if level:
+                controls["emphasis.level"] = level
+        elif elem.tag == "break":
+            time = elem.attrib.get("time")
+            if time and time.endswith("ms"):
+                try:
+                    controls["break.ms"] = int(time[:-2])
+                except ValueError:
+                    pass
+        if elem.text:
+            parts.append(elem.text)
+        if elem.tail:
+            parts.append(elem.tail)
+
+    plain = "".join(parts).strip()
+    return plain, controls

--- a/tests/tts/test_streaming_interruptions.py
+++ b/tests/tts/test_streaming_interruptions.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import time
+
+from src.voice import NullTTSAdapter, TTSRequest
+
+
+def test_barge_in_interrupt():
+    adapter = NullTTSAdapter()
+    req = TTSRequest(text="hello world " * 100)
+    start = time.monotonic()
+    stream = adapter.synthesize_stream(req)
+    data = bytearray()
+    for i, chunk in enumerate(stream):
+        data.extend(chunk.data)
+        if i == 1:
+            break
+    elapsed = time.monotonic() - start
+    assert elapsed < 0.25
+    assert data
+
+
+def test_full_stream_receives_final_chunk():
+    adapter = NullTTSAdapter()
+    req = TTSRequest(text="hello world " * 10)
+    chunks = list(adapter.synthesize_stream(req))
+    assert chunks[-1].final

--- a/tests/tts/test_tts_adapters.py
+++ b/tests/tts/test_tts_adapters.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import pytest
+
+from src.voice import NullTTSAdapter, PiperTTSStub, TTSRequest, parse_ssml
+
+
+@pytest.mark.parametrize("adapter_cls", [NullTTSAdapter, PiperTTSStub])
+def test_streaming(adapter_cls):
+    adapter = adapter_cls()
+    text = "hello world " * 50
+    req = TTSRequest(text=text)
+    chunks = list(adapter.synthesize_stream(req))
+    assert len(chunks) >= 2
+    assert sum(len(c.data) for c in chunks) >= len(text)
+    assert sum(1 for c in chunks if c.final) == 1
+    seqs = [c.seq for c in chunks]
+    assert seqs == sorted(seqs)
+
+
+def test_ssml_parsing_with_null_adapter():
+    ssml = (
+        '<prosody rate="fast"><emphasis level="strong">hello'
+        '</emphasis><break time="500ms"/></prosody>'
+    )
+    text, controls = parse_ssml(ssml)
+    assert text == "hello"
+    assert controls == {
+        "prosody.rate": "fast",
+        "emphasis.level": "strong",
+        "break.ms": 500,
+    }
+    adapter = NullTTSAdapter()
+    req = TTSRequest(text=ssml, ssml=True)
+    data = b"".join(chunk.data for chunk in adapter.synthesize_stream(req))
+    assert data.decode() == text
+
+
+def test_piper_stub_requires_plain_text():
+    ssml = '<emphasis level="moderate">hi there</emphasis>'
+    text, _ = parse_ssml(ssml)
+    adapter = PiperTTSStub()
+    assert adapter.supports_ssml() is False
+    req = TTSRequest(text=text)
+    data = b"".join(chunk.data for chunk in adapter.synthesize_stream(req))
+    assert data.decode() == text


### PR DESCRIPTION
## Summary
- Introduce minimal text-to-speech interface with request/chunk dataclasses and an SSML parser.
- Provide null and Piper stub adapters for streaming synthesis.
- Add tests validating streaming behavior, SSML parsing, and barge‑in interruption handling.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68c795ea3d00832ab586b9270ada9aeb