### PR TITLE
Handle missing requests in ElevenLabs adapter

### DIFF
--- a/src/tts_elevenlabs.py
+++ b/src/tts_elevenlabs.py
@@ -4,8 +4,15 @@ from __future__ import annotations
 
 import os
 from typing import Iterable
+from types import SimpleNamespace
 
-import requests
+try:  # pragma: no cover - exercised via tests
+    import requests  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover
+    def _missing_requests(*args, **kwargs):
+        raise RuntimeError("requests library is required for ElevenLabs TTS")
+
+    requests = SimpleNamespace(post=_missing_requests)
 
 
 def synthesize(


### PR DESCRIPTION
## Summary
- Avoid `ImportError` when the optional `requests` dependency is absent for ElevenLabs TTS.

## Testing
- `python -m py_compile src/tts_elevenlabs.py`
- `pytest -m "not slow" --maxfail=1`
- `pytest -m "not slow" --cov=src --cov-report=xml --cov-report=term-missing --cov-fail-under=100` *(fails: Coverage failure: total of 99 is less than fail-under=100)*

------
https://chatgpt.com/codex/tasks/task_b_68c79bee543c832a831c5d6fd155c17a