### PR TITLE
test: ensure NullTTSAdapter supports SSML

### DIFF
--- a/tests/tts/test_null_adapter_supports_ssml.py
+++ b/tests/tts/test_null_adapter_supports_ssml.py
@@ -1,0 +1,6 @@
+from src.voice import NullTTSAdapter
+
+
+def test_null_adapter_supports_ssml() -> None:
+    adapter = NullTTSAdapter()
+    assert adapter.supports_ssml() is True


### PR DESCRIPTION
## Summary
- add test checking `NullTTSAdapter.supports_ssml()` returns True

## Testing
- `pre-commit run --files tests/tts/test_null_adapter_supports_ssml.py`
- `pytest -m "not slow" --cov=src --cov-fail-under=100`


------
https://chatgpt.com/codex/tasks/task_b_68c7b0bf4fc0832a9642fbbfd82650fa