### PR TITLE
test: cover additional ssml parsing cases

### DIFF
--- a/tests/tts/test_tts_adapters.py
+++ b/tests/tts/test_tts_adapters.py
@@ -47,12 +47,20 @@ def test_piper_stub_requires_plain_text():
     assert data.decode() == text
 
 
-def test_parse_ssml_errors_and_tail():
+def test_parse_ssml_malformed_returns_original_text():
     malformed = "<emphasis>oops"
     text, controls = parse_ssml(malformed)
     assert text == malformed
     assert controls == {}
 
-    text, controls = parse_ssml('<break time="oopsms"/>after')
-    assert text == "after"
+
+def test_parse_ssml_break_with_invalid_time():
+    text, controls = parse_ssml('<break time="oopsms"/>')
+    assert text == ""
     assert controls == {}
+
+
+def test_parse_ssml_appends_tail_text():
+    text, controls = parse_ssml('<break time="1ms"/>after')
+    assert text == "after"
+    assert controls == {"break.ms": 1}


### PR DESCRIPTION
## Summary
- add tests for malformed SSML to trigger ParseError
- add tests for break tags with invalid time to exercise ValueError branch
- verify tail text handling when parsing SSML

## Testing
- `pytest -m "not slow" --cov=src --cov-fail-under=100`

------
https://chatgpt.com/codex/tasks/task_b_68c7b32a8b14832a9f4249fa89dfd4f0