### PR TITLE
Add dedicated tests for parse_ssml edge cases

### DIFF
--- a/tests/tts/test_parse_ssml.py
+++ b/tests/tts/test_parse_ssml.py
@@ -1,0 +1,22 @@
+import pytest
+
+from src.voice import parse_ssml
+
+
+def test_parse_ssml_malformed_returns_original_text():
+    malformed = "<emphasis>oops"
+    text, controls = parse_ssml(malformed)
+    assert text == malformed
+    assert controls == {}
+
+
+def test_parse_ssml_break_with_invalid_time():
+    text, controls = parse_ssml('<break time="oopsms"/>')
+    assert text == ""
+    assert controls == {}
+
+
+def test_parse_ssml_appends_tail_text():
+    text, controls = parse_ssml('<break time="1ms"/>after')
+    assert text == "after"
+    assert controls == {"break.ms": 1}

--- a/tests/tts/test_tts_adapters.py
+++ b/tests/tts/test_tts_adapters.py
@@ -45,22 +45,3 @@ def test_piper_stub_requires_plain_text():
     req = TTSRequest(text=text)
     data = b"".join(chunk.data for chunk in adapter.synthesize_stream(req))
     assert data.decode() == text
-
-
-def test_parse_ssml_malformed_returns_original_text():
-    malformed = "<emphasis>oops"
-    text, controls = parse_ssml(malformed)
-    assert text == malformed
-    assert controls == {}
-
-
-def test_parse_ssml_break_with_invalid_time():
-    text, controls = parse_ssml('<break time="oopsms"/>')
-    assert text == ""
-    assert controls == {}
-
-
-def test_parse_ssml_appends_tail_text():
-    text, controls = parse_ssml('<break time="1ms"/>after')
-    assert text == "after"
-    assert controls == {"break.ms": 1}


### PR DESCRIPTION
## Summary
- Cover parse_ssml error handling for malformed SSML and invalid break times
- Assert tail text is preserved after valid break tags

## Testing
- `pytest -m "not slow" --cov=src --cov-fail-under=100`


------
https://chatgpt.com/codex/tasks/task_b_68c7b8402108832a96323f969bdd1be8