### PR TITLE
test: verify NullTTSAdapter SSML support

### DIFF
--- a/tests/tts/test_null_adapter_supports_ssml.py
+++ b/tests/tts/test_null_adapter_supports_ssml.py
@@ -1,4 +1,4 @@
-from src.voice import NullTTSAdapter
+from src.voice.adapters.tts_null import NullTTSAdapter
 
 def test_null_adapter_supports_ssml() -> None:
     adapter = NullTTSAdapter()


### PR DESCRIPTION
## Summary
- ensure NullTTSAdapter declares SSML support via explicit import

## Testing
- `pytest -m "not slow" --cov=src --cov-fail-under=100`


------
https://chatgpt.com/codex/tasks/task_b_68c7baa66b4c832ab370fc7fef537ab5