### PR TITLE
test: cover parse_ssml parse error

### DIFF
--- a/tests/tts/test_parse_ssml_parse_error.py
+++ b/tests/tts/test_parse_ssml_parse_error.py
@@ -1,0 +1,8 @@
+from src.voice import parse_ssml
+
+
+def test_parse_ssml_returns_original_on_parse_error():
+    malformed = "<emphasis>oops"
+    text, controls = parse_ssml(malformed)
+    assert text == malformed
+    assert controls == {}


### PR DESCRIPTION
## Summary
- add regression test confirming parse_ssml returns original text and no controls on invalid SSML

## Testing
- `pytest tests/tts --cov=src.voice.tts -q`


------
https://chatgpt.com/codex/tasks/task_b_68c7bc4ff1cc832a98b81913259a8675