### PR TITLE
test: cover invalid break time

### DIFF
--- a/tests/tts/test_parse_ssml_invalid_break_time_single_quotes.py
+++ b/tests/tts/test_parse_ssml_invalid_break_time_single_quotes.py
@@ -1,0 +1,7 @@
+from src.voice import parse_ssml
+
+
+def test_parse_ssml_break_with_invalid_time_single_quotes():
+    text, controls = parse_ssml("<break time='oopsms'/>")
+    assert text == ""
+    assert controls == {}


### PR DESCRIPTION
## Summary
- add test for `<break time='oopsms'/>` to hit `ValueError` path

## Testing
- `pre-commit run --files tests/tts/test_parse_ssml_invalid_break_time_single_quotes.py`
- `pytest tests/tts/test_parse_ssml.py tests/tts/test_parse_ssml_parse_error.py tests/tts/test_tts_adapters.py tests/tts/test_parse_ssml_invalid_break_time_single_quotes.py --maxfail=1 --disable-warnings -q --cov=src.voice.tts`


------
https://chatgpt.com/codex/tasks/task_b_68c7c6b38cc0832a830cd0c532a981ef