### PR TITLE
chore(ui): align vitest dependency versions

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -27,7 +27,7 @@
     "@types/react": "^19.1.13",
     "@types/react-dom": "^19.1.9",
     "@vitejs/plugin-react-swc": "^4.0.1",
-    "@vitest/coverage-v8": "^3.2.4",
+    "@vitest/coverage-v8": "3.2.4",
     "eslint": "^9.35.0",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",
@@ -37,7 +37,7 @@
     "prop-types": "^15.8.1",
     "typescript": "^5.5.4",
     "vite": "^7.1.5",
-    "vitest": "^3.2.4"
+    "vitest": "3.2.4"
   },
   "dependencies": {
     "@emotion/react": "^11.11.4",

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -52,7 +52,7 @@ importers:
         specifier: ^4.0.1
         version: 4.0.1(vite@7.1.5(@types/node@24.3.1))
       '@vitest/coverage-v8':
-        specifier: ^3.2.4
+        specifier: 3.2.4
         version: 3.2.4(vitest@3.2.4(@types/node@24.3.1)(jsdom@27.0.0(postcss@8.5.6))(msw@2.11.2(@types/node@24.3.1)(typescript@5.9.2)))
       eslint:
         specifier: ^9.35.0
@@ -82,7 +82,7 @@ importers:
         specifier: ^7.1.5
         version: 7.1.5(@types/node@24.3.1)
       vitest:
-        specifier: ^3.2.4
+        specifier: 3.2.4
         version: 3.2.4(@types/node@24.3.1)(jsdom@27.0.0(postcss@8.5.6))(msw@2.11.2(@types/node@24.3.1)(typescript@5.9.2))
 
 packages:


### PR DESCRIPTION
## Summary
- pin `vitest` and `@vitest/coverage-v8` to the same 3.2.4 release
- refresh the pnpm lockfile to capture the pinned versions

## Testing
- pnpm test:ci


------
https://chatgpt.com/codex/tasks/task_b_68c888ba4270832a89d25d2a9eea1123