### PR TITLE
Update REFRAG projection notation

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -173,7 +173,7 @@ flowchart TB
     vLLM[vLLM / SGLang]
     TRT[TensorRT-LLM]
     Triton[Triton Inference Server]
-    REFRAGE[REFRAG Encoder + Projection]
+    REFRAGE[REFRAG Encoder + φ Projection]
     Z3[Z3 / Prolog Solvers]
   end
 


### PR DESCRIPTION
## Summary
- clarify the serving engines mermaid diagram to specify the φ projection used by the REFRAG encoder

## Testing
- not run (documentation change)


------
https://chatgpt.com/codex/tasks/task_b_68c8e44f0ed8832ab5fcac136b730785