### PR TITLE
docs: add DeepDive reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ Spec and scaffolding guidance in [VS Code Extension](docs/VS_CODE_EXTENSION.md).
 
 - **Agentic Orchestration** — multi-phase workflows you can trace and audit.
 - **Multi-Model Routing** — cost/latency-aware routes across NIM, vLLM, and a small model tier.
+- **Model+tool orchestration** — Router chooses LLM/tools using live telemetry + historical
+  win-rates; bandit updates; federated learning for privacy.
+  > Informed by [DeepDive] (arXiv:2507.02592), which shows how knowledge-graph–grounded data and
+  > multi-turn RL improve web agent training and orchestration fidelity.
 - **RAG on Postgres + pgvector** — BM25 + cosine + feedback reranker.
 - **Secure Sandbox** — Docker-executed verification with seccomp + no-network.
 - **PII Calibration** — Shannon entropy thresholds with a 550-item dataset.
@@ -248,3 +252,5 @@ MIT — see [License](LICENSE).
 - **AutoAgent** — clustered agents.
 - **MetaCLIP2** — multilingual vision-text embeddings for cross-modal retrieval and grounding.
 - **Fusion Controller** — real-time multimodal streams (video/audio, depth, pose, motion masks). Evaluation datasets include SpatialVID (~7K hrs with depth, pose, object masks, motion trends).
+ 
+[DeepDive]: REFERENCES.md#research--concepts

--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -8,6 +8,11 @@ docs. Keep it authoritative and in sync with `ROADMAP.md`. For collaboration mod
 
 ## Research & Concepts
 
+- **DeepDive: Advancing Deep Search Agents with Knowledge Graphs and Multi-Turn RL**  
+  arXiv:2507.02592 (July 2025).  
+  Trains web agents on knowledge-graph–constructed datasets with multi-turn RL, improving retrieval,
+  grounding, and multi-hop query performance.  
+  PDF: https://arxiv.org/abs/2507.02592
 - Tool-space interference in the MCP era
 - Paper2Agent
 - Virtual Agent Economies

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -40,6 +40,8 @@ through AnyLLM (plus official SDKs). Safety via NeMo Guardrails / Guardrails AI.
    criteria; agentic RAG and adaptive sources.
 2. **Model+tool orchestration** — Router chooses LLM/tools using live telemetry + historical
    win-rates; bandit updates; federated learning for privacy.
+   > Informed by [DeepDive] (arXiv:2507.02592), which shows how knowledge-graph–grounded data and
+   > multi-turn RL improve web agent training and orchestration fidelity.
 3. **Formalized self-improvement** — Self-PRs (prompt/router/config/test deltas) gated by
    evals/canary; AlphaEvolve-style optimization for hot paths (see [Bootstrapping Task Spaces]).
    > Backed by recent research (AlphaXiv 2509.02359v1) showing how autonomous agents can decompose
@@ -545,6 +547,7 @@ constitutional bypass.
   **Exit Criteria:**
 - Complex multi-source Qs solved
 - Full trace in Studio UI
+- Multi-turn web agent demo (DeepDive-inspired KG+RL data) shows measurable accuracy gains vs. naive retrieval
 
 ---
 
@@ -873,3 +876,4 @@ Every LLM span must include:
 [Paper2Agent]: REFERENCES.md#research--concepts
 [All You Need Is A Fuzzing Brain]: REFERENCES.md#research--concepts
 [Statistical Methods in Generative AI]: REFERENCES.md#research--concepts
+[DeepDive]: REFERENCES.md#research--concepts


### PR DESCRIPTION
## Summary
- document model+tool orchestration research link
- cite DeepDive paper in roadmap and references
- note multi-turn web agent demo exit criterion

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68c90655a150832a9d8997e8330c6998