### PR TITLE
docs: restore DeepDive citations after rebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ Spec and scaffolding guidance in [VS Code Extension](docs/VS_CODE_EXTENSION.md).
 ## ✨ Features
 
 - **Agentic Orchestration** — multi-phase workflows you can trace and audit.
+- **Model+tool orchestration** — Router chooses LLM/tools using live telemetry + historical
+  win-rates (see [DeepDive](https://arxiv.org/abs/2507.02592)).
 - **Multi-Model Routing** — cost/latency-aware routes across NIM, vLLM, and a small model tier.
 - **RAG on Postgres + pgvector** — BM25 + cosine + feedback reranker.
 - **Secure Sandbox** — Docker-executed verification with seccomp + no-network.

--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -12,6 +12,8 @@ docs. Keep it authoritative and in sync with `ROADMAP.md`. For collaboration mod
 - Paper2Agent
 - Virtual Agent Economies
 - Bootstrapping Task Spaces for Self-Improvement
+- DeepDive: Advancing Deep Search Agents with Knowledge Graphs and Multi-Turn RL —
+  arXiv:2507.02592 — <https://arxiv.org/abs/2507.02592>
 - The Illusion of Diminishing Returns: Measuring Long Horizon Execution in LLMs
 - Why Language Models Hallucinate
 - Reasoning Introduces New Poisoning Attacks Yet Makes Them More Complicated

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -545,6 +545,8 @@ constitutional bypass.
   **Exit Criteria:**
 - Complex multi-source Qs solved
 - Full trace in Studio UI
+- Multi-turn web agent demo (DeepDive-inspired KG+RL data) shows measurable accuracy gains vs.
+  naive retrieval.
 
 ---
 


### PR DESCRIPTION
## Summary
- restore the README features bullet for DeepDive-backed model and tool orchestration
- add the DeepDive research entry back into the centralized references list
- reinstate the DeepDive-inspired exit criterion for the Phase I agentic RAG roadmap

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_b_68c907bd50d4832a9355fb7fa03f555c