### PR TITLE
Update roadmap with modular RAG evolution reference

### DIFF
--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -68,6 +68,11 @@ docs. Keep it authoritative and in sync with `ROADMAP.md`. For collaboration mod
   - Code — _link TBD_
   - Summary — Reuses retrieval across decoding to accelerate streaming RAG, yielding ~30.8× faster
     TTFT, 16× longer context handling, and no accuracy loss.
+- **RAG’s Biggest Lie — Retrieval-Augmented Generation for Large Language Models: A Survey** —
+  <https://arxiv.org/abs/2312.10997>
+  - Summary — Comprehensive survey that formalizes Naive, Advanced, and Modular/Self-RAG
+    paradigms, detailing retrieval granularity, adaptive planning, and evaluation gaps for
+    production-grade systems.
 - **GraphRAG** — <https://github.com/microsoft/graphrag>
 - **LazyGraphRAG** — <https://github.com/sanikacentric/LazyGraphRAG>
 - **Firecrawl (crawl → extract → chunk → index)** — <https://github.com/mendableai/firecrawl>

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,6 +8,9 @@ References for external resources are centralized in [REFERENCES.md](REFERENCES.
   aware compression pipeline that unlocks ~30.8× faster TTFT (time-to-first-token) while enabling
   16× effective context windows for open-weight models. Read the full paper here:
   [REFRAG: Retrieval Enhanced Fragmentation for Long-Context LLMs (PDF)](https://arxiv.org/pdf/2509.01092).
+- **Modular Self-RAG evolution** — Self-RAG is now organized into pluggable retrieval, planning,
+  verification, and critique loops so orchestrated agents can adapt depth, abstention, and
+  grounding policies per task—directly addressing the systemic gaps surfaced in [RAG’s Biggest Lie].
 - **Naestro integration** — Naestro exposes REFRAG through the dedicated REFRAG Controller coupled
   with vLLM/TensorRT-LLM serving adapters so orchestrated agents can transparently benefit from
   accelerated long-context inference.
@@ -880,6 +883,7 @@ interventions, and instrumented explanations aligned to Phase U goals.
 [MCP-DevMode]: REFERENCES.md#tooling--connectors--protocols
 [n8n]: REFERENCES.md#tooling--connectors--protocols
 [Nango]: REFERENCES.md#tooling--connectors--protocols
+[RAG’s Biggest Lie]: REFERENCES.md#retrieval--rag
 [Firecrawl]: REFERENCES.md#retrieval--rag
 [Gitingest]: REFERENCES.md#retrieval--rag
 [LangGraph]: REFERENCES.md#agent-runtimes--frameworks--interop


### PR DESCRIPTION
## Summary
- document the modular Self-RAG evolution in the roadmap and tie it to the recent "RAG's Biggest Lie" survey
- add the corresponding reference entry in REFERENCES.md for the Retrieval-Augmented Generation survey

## Testing
- not run (documentation updates only)


------
https://chatgpt.com/codex/tasks/task_b_68ca644a34b4832a896377c01139ab93