### PR TITLE
Update hallucination resilience roadmap description

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -53,7 +53,8 @@ through AnyLLM (plus official SDKs). Safety via NeMo Guardrails / Guardrails AI.
 5. **Observability & provenance** — Logs, metrics, traces; signed artifacts; time-travel debugging;
    metacognitive narratives.
 6. **Hallucination-resilience** — Retrieval-first planning, claim verifier, abstention, CoVe;
-   citation-grounded outputs (informed by [Why LMs Hallucinate]).
+   citation-grounded outputs (informed by [Why LMs Hallucinate]) and adoption of noise-aware
+   retrieval strategies inspired by insights from [RAG’s Biggest Lie].
 7. **Long-context acceleration** — REFRAG lane for open-weights (**16×** effective context, ~30×
    TTFT (time-to-first-token)); bypass for closed APIs.
 8. **AgentOps maturity** — Multi-agent plans, HITL evaluation, trajectory/final-response scoring,


### PR DESCRIPTION
## Summary
- expand the hallucination-resilience roadmap bullet with noise-aware retrieval strategies informed by the RAG's Biggest Lie findings

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_b_68ca66504dd0832aad0f33ef6d852fb6