### PR TITLE
Update Phase I Agentic RAG deliverables

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -569,12 +569,14 @@ regimes on H100/next-gen accelerators.
 **Deliverables:**
 
 - Researcher/Validator agents
-- Multi-hop query expansion + evidence synth  
+- Multi-hop query expansion + evidence synth
+- Self-RAG-aligned iterative retrieval loops (retrieve → critique → refine)
+- Embedded self-critique routines with traceable verifier feedback cycles
   **Exit Criteria:**
-- Complex multi-source Qs solved
-- Full trace in Studio UI
+- Complex multi-source Qs solved with documented critique/refine iterations
+- Full trace in Studio UI capturing retrieval loops and critique artifacts
 - Multi-turn web agent demo (DeepDive-inspired KG+RL data) shows measurable accuracy gains vs. naive
-  retrieval.
+  retrieval, including ablation evidencing the self-critique + iterative retrieval uplift.
 
 ---
 


### PR DESCRIPTION
## Summary
- expand Phase I Agentic RAG deliverables to cover Self-RAG style iterative retrieval and self-critique loops
- update exit criteria to require documented critique/refinement iterations and evidence of uplift from the enhanced loops

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_b_68ca6723e348832ab0d3e58e1965d37d