### PR TITLE
docs: reference FlowTemplate backlog in roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Spec and scaffolding guidance in [VS Code Extension](docs/VS_CODE_EXTENSION.md).
 
 - **FlowTemplate** — Browse thousands of automation workflows for n8n, Make.com, Zapier.
   - [Catalog](https://flowtemplate.com/workflows) · [Overview](https://flowtemplate.com/) · [Guide](https://flowtemplate.com/guide)
+  - ℹ️ FlowTemplate module backlog updates live in [ROADMAP.md §11](./ROADMAP.md#11-filemodule-backlog) (connectors, converters, sanitizers, evaluators, studio import components).
 
 ---
 


### PR DESCRIPTION
## Summary
- direct README readers to the FlowTemplate backlog entries tracked in ROADMAP.md §11

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_b_68ca6cd800c0832a9d6064f029139aca