### PR TITLE
Add requests dependency for voice integrations

### DIFF
--- a/requirements.lock
+++ b/requirements.lock
@@ -4,11 +4,21 @@
 #
 #    pip-compile --output-file=requirements.lock requirements.txt
 #
+certifi==2025.8.3
+    # via requests
+charset-normalizer==3.4.3
+    # via requests
+idna==3.10
+    # via requests
 mpmath==1.3.0
     # via sympy
 numpy==2.3.2
     # via scipy
+requests==2.32.4
+    # via -r requirements.txt
 scipy==1.16.1
     # via -r requirements.txt
 sympy==1.14.0
     # via -r requirements.txt
+urllib3==2.5.0
+    # via requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 sympy==1.14.0
 scipy==1.16.1
+requests==2.32.4

--- a/src/gateway/requirements.lock
+++ b/src/gateway/requirements.lock
@@ -14,6 +14,9 @@ certifi==2025.8.3
     # via
     #   httpcore
     #   httpx
+    #   requests
+charset-normalizer==3.4.3
+    # via requests
 click==8.2.1
     # via uvicorn
 fastapi==0.116.1
@@ -30,6 +33,7 @@ idna==3.10
     # via
     #   anyio
     #   httpx
+    #   requests
 prometheus-client==0.22.1
     # via -r src/gateway/requirements.txt
 pydantic==2.11.7
@@ -37,6 +41,8 @@ pydantic==2.11.7
 pydantic-core==2.33.2
     # via pydantic
 python-dotenv==1.1.1
+    # via -r src/gateway/requirements.txt
+requests==2.32.4
     # via -r src/gateway/requirements.txt
 sniffio==1.3.1
     # via anyio
@@ -52,5 +58,7 @@ typing-extensions==4.14.1
     #   typing-inspection
 typing-inspection==0.4.1
     # via pydantic
+urllib3==2.5.0
+    # via requests
 uvicorn==0.35.0
     # via -r src/gateway/requirements.txt

--- a/src/gateway/requirements.txt
+++ b/src/gateway/requirements.txt
@@ -2,4 +2,5 @@ fastapi==0.116.1
 uvicorn==0.35.0
 httpx==0.28.1
 prometheus-client==0.22.1
+requests==2.32.4
 python-dotenv==1.1.1


### PR DESCRIPTION
## Summary
- add requests==2.32.4 to the root Python requirements so voice providers have the client installed
- add the same pin to the gateway service requirements and regenerate both lockfiles

## Testing
- pytest tests/tts/test_adapters.py

------
https://chatgpt.com/codex/tasks/task_b_68cb2280ea48832a964f3184f67e1237