### PR TITLE
Add PyYAML dependency for voice route

### DIFF
--- a/requirements.lock
+++ b/requirements.lock
@@ -14,6 +14,8 @@ mpmath==1.3.0
     # via sympy
 numpy==2.3.2
     # via scipy
+pyyaml==6.0.2
+    # via -r requirements.txt
 requests==2.32.4
     # via -r requirements.txt
 scipy==1.16.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-sympy==1.14.0
-scipy==1.16.1
+pyyaml==6.0.2
 requests==2.32.4
+scipy==1.16.1
+sympy==1.14.0

--- a/src/gateway/requirements.lock
+++ b/src/gateway/requirements.lock
@@ -42,6 +42,8 @@ pydantic-core==2.33.2
     # via pydantic
 python-dotenv==1.1.1
     # via -r src/gateway/requirements.txt
+pyyaml==6.0.2
+    # via -r src/gateway/requirements.txt
 requests==2.32.4
     # via -r src/gateway/requirements.txt
 sniffio==1.3.1

--- a/src/gateway/requirements.txt
+++ b/src/gateway/requirements.txt
@@ -3,4 +3,5 @@ uvicorn==0.35.0
 httpx==0.28.1
 prometheus-client==0.22.1
 requests==2.32.4
+pyyaml==6.0.2
 python-dotenv==1.1.1


### PR DESCRIPTION
## Summary
- add PyYAML to the shared Python requirements so voice routing code can import yaml
- regenerate the root and gateway lock files after including the new dependency

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68cb272a57d0832aa7990308c15f573f