### PR TITLE
Add agency automation use case to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ depth.
 
 See also: [References](./REFERENCES.md) for external tech and source links.
 
+Use-Cases:
+- [Agency Automation (n8n + Naestro)](docs/usecases/agency_automation.md)
+
 ---
 
 ## Vision


### PR DESCRIPTION
## Summary
- add a Use-Cases list near the top-level resource links in the README
- link the Agency Automation (n8n + Naestro) documentation from the new list

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_b_68cb32c6c1fc832abc667d9ce6a70d16