### PR TITLE
Update Phase E InfoSeek deliverable wording

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -504,7 +504,7 @@ constitutional bypass.
 - Introspector: detect reusable subplans
 - Skill registry (typed, versioned)
 - InfoSeek evaluation lane — integrate [InfoSeek][InfoSeek] tasks via [InfoSeek Framework][InfoSeek
-  Framework] to benchmark deep research planning and browse tooling.
+  Framework] to benchmark deep research planning, researcher evals, and Agentic RAG stress tests.
   **Exit Criteria:**
 - Router converges to cheaper/better models
 - ≥5 skills encapsulated as registry items


### PR DESCRIPTION
## Summary
- update the Phase E InfoSeek evaluation lane bullet to include researcher evals and Agentic RAG stress tests

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_b_68cb4e8ff4f0832aabc1d161dad160bf