### PR TITLE
Add Magistral references and align InfoSeek anchors

### DIFF
--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -27,8 +27,10 @@ docs. Keep it authoritative and in sync with `ROADMAP.md`. For collaboration mod
 [Casbin]: REFERENCES.md#identitypolicy
 [Keycloak]: REFERENCES.md#identitypolicy
 [Ling-flash-2.0]: REFERENCES.md#models--architectures
+[Magistral 1.2]: REFERENCES.md#models--architectures
+[Magistral Docs]: REFERENCES.md#models--architectures
 [InfoSeek]: REFERENCES.md#datasets
-[InfoSeekFramework]: REFERENCES.md#datasets
+[InfoSeek Framework]: REFERENCES.md#datasets
 
 ## Research & Concepts
 
@@ -71,14 +73,16 @@ docs. Keep it authoritative and in sync with `ROADMAP.md`. For collaboration mod
   - NVIDIA Model Card — <https://build.nvidia.com/qwen/qwen3-next-80b-a3b-thinking/modelcard>
 - **Ling-flash-2.0** — 100B total parameters with ~6.1B activated (≈4.8B non-embedding) delivering ~7× dense-model efficiency and 128K-context throughput for high-speed reasoning workloads.
   - Paper — _Every FLOP Counts: Scaling a 300B Mixture-of-Experts LING LLM without Premium GPUs_ — <https://arxiv.org/abs/2503.05139>
+- **Magistral 1.2** — Magistral AI's chain-of-thought content generation suite combining URL-based sourcing, targeted Google search/news synthesis, and multimodal ingestion (PDF, YouTube, podcasts) for research-grade article workflows. <https://magistral.ai>
+  - Docs — <https://docs.magistral.ai>
 
 ## Datasets
 
 - **SpatialVID** — _A Large-Scale Video Dataset with Spatial Annotations_ (NJU-3DV, 2025). ~7K hours
   of video with annotations: camera pose, depth maps, dynamic object masks, scene text descriptions
   (camera, motion trends, summary). Project — <https://nju-3dv.github.io/projects/SpatialVID>
-- **InfoSeek** — _Open Data Synthesis For Deep Research_ (Ziyi Xia et al., 2025). Hierarchical constraint-satisfaction tasks (50K train, curated eval, reject-sampled trajectories) that stress deep research planning and BrowseComp-Plus benchmarking. Paper — <https://arxiv.org/abs/2509.00375>
-- **InfoSeek Framework** — Dual-agent synthesis stack that mines entities/relations, constructs research trees, and emits meta-tagged question decompositions for compound reward design. Code — <https://github.com/VectorSpaceLab/InfoSeek>
+- **[InfoSeek][InfoSeek]** — _Open Data Synthesis For Deep Research_ (Ziyi Xia et al., 2025). Hierarchical constraint-satisfaction tasks (50K train, curated eval, reject-sampled trajectories) that stress deep research planning and BrowseComp-Plus benchmarking. Paper — <https://arxiv.org/abs/2509.00375>
+- **[InfoSeek Framework][InfoSeek Framework]** — Dual-agent synthesis stack that mines entities/relations, constructs research trees, and emits meta-tagged question decompositions for compound reward design. Code — <https://github.com/VectorSpaceLab/InfoSeek>
 
 ## Retrieval & RAG
 


### PR DESCRIPTION
## Summary
- add Magistral 1.2 to the models/architectures references with a dedicated docs link
- rename the InfoSeek Framework anchor and update the dataset bullets to use the new reference labels

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_b_68cb5106dfec832a801717ceaff46a3f