### PR TITLE
Add Grok 4 cloud entry to models config

### DIFF
--- a/configs/models.yaml
+++ b/configs/models.yaml
@@ -37,3 +37,16 @@ routers:
       - magistral
       - router
       - preview
+
+cloud:
+  - name: grok-4
+    provider: xai
+    capabilities:
+      - reasoning
+      - long_context
+      - coding
+    priority: 90
+    notes: >-
+      Grok 4 cloud-tier allocation used for overflow reasoning bursts,
+      multi-hop research assistance, and long-context synthesis when local
+      routers are saturated.


### PR DESCRIPTION
## Summary
- add the Grok 4 cloud configuration alongside the existing router entries

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68cb536538c0832a840ea877ef894130