### PR TITLE
Update AgentScope reference in REFERENCES.md

### DIFF
--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -31,6 +31,7 @@ docs. Keep it authoritative and in sync with `ROADMAP.md`. For collaboration mod
 [Magistral Docs]: REFERENCES.md#models--architectures
 [InfoSeek]: REFERENCES.md#datasets
 [InfoSeek Framework]: REFERENCES.md#datasets
+[AgentScope]: https://github.com/agentscope-ai/agentscope
 
 ## Research & Concepts
 
@@ -155,7 +156,7 @@ docs. Keep it authoritative and in sync with `ROADMAP.md`. For collaboration mod
 
 - **LangGraph** — <https://github.com/langchain-ai/langgraph>
 - **CrewAI** — <https://github.com/joaomdmoura/crewai>
-- **AgentScope** — <https://github.com/modelscope/agentscope>
+- **AgentScope** — [AgentScope]
 - **AutoGen** — <https://github.com/microsoft/autogen>
 - **SuperAGI** — <https://github.com/TransformerOptimus/SuperAGI>
 - **AutoAgent (clustered swarms)** — <https://github.com/Link-AGI/AutoAgents>


### PR DESCRIPTION
## Summary
- switch the AgentScope bullet in the Agent Runtimes / Frameworks & Interop section to use a reference-style link
- add a shared AgentScope reference pointing at the agentscope-ai repository

## Testing
- No tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_b_68cc73d8d750832a9a32cce5d40b3d7e