### PR TITLE
Add AgentScope runtime configuration

### DIFF
--- a/configs/runtimes.yaml
+++ b/configs/runtimes.yaml
@@ -1,0 +1,6 @@
+runtimes:
+  agentscope:
+    enabled: false
+    notes: "Alibaba AgentScope; enable after adapter spike"
+    policy_contract: "opa/casbin"
+    tracing: "otel"


### PR DESCRIPTION
## Summary
- add a runtimes configuration file that registers the AgentScope runtime and its default metadata

## Testing
- python - <<'PY'
import yaml
with open('configs/runtimes.yaml') as f:
    data = yaml.safe_load(f)
print(data)
PY


------
https://chatgpt.com/codex/tasks/task_b_68cc750d3594832a8b4dc65730f51718