### PR TITLE
docs: update changelog for AgentScope notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented here. This project adhere
 
 ## [Unreleased]
 
-- Added: AgentScope runtime listing documentation and Mermaid diagram.
+- Added: AgentScope runtime listing docs + Mermaid diagram.
 - Added: Adapter/config stub for AgentScope integrations.
 - Updated: **VISION.md** with Engineering Quality, Meta-Cognition, Ecosystem, and Governance sections
 - Updated: cross-links in README/ROADMAP; added reference anchors


### PR DESCRIPTION
## Summary
- clarify the changelog entry for the AgentScope runtime listing to mention docs + Mermaid diagram
- keep the adapter/config stub note under the unreleased section

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68cc97e8ebd4832ab1be55f818b50e1c