### PR TITLE
Add DeepCode plugin configuration

### DIFF
--- a/configs/plugins.yaml
+++ b/configs/plugins.yaml
@@ -1,0 +1,5 @@
+plugins:
+  deepcode:
+    enabled: false
+    repo_dir: /workspace/naestro
+    notes: "DeepCode adapter is not wired yet"


### PR DESCRIPTION
## Summary
- add the plugins.yaml config file for the DeepCode plugin
- set the plugin disabled by default with the repository root as the repo_dir
- document that the DeepCode adapter is not wired yet in the notes field

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68ccc1fd602c832a827e57935539e437