### PR TITLE
Add FastAPI route for DeepCode plugin

### DIFF
--- a/api/routes/plugins.py
+++ b/api/routes/plugins.py
@@ -1,0 +1,83 @@
+"""Plugin routes for interacting with optional integrations."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import yaml
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from integrations.plugins.deepcode_adapter import DeepCodeAdapter
+
+
+CONFIG_PATH = Path(__file__).resolve().parents[2] / "configs" / "plugins.yaml"
+
+router = APIRouter()
+
+
+class DeepCodeBuildRequest(BaseModel):
+    """Payload for DeepCode build requests."""
+
+    source: Any | None = None
+
+
+class DeepCodeBuildResponse(BaseModel):
+    """Schema describing the DeepCode adapter response."""
+
+    status: str
+    message: str
+    source: Any | None = None
+
+
+def _load_plugins_config(path: Path | None = None) -> Mapping[str, Any]:
+    """Load plugin configuration from YAML, returning an empty mapping on error."""
+
+    if path is None:
+        path = CONFIG_PATH
+
+    if not path.exists():
+        return {}
+
+    with path.open("r", encoding="utf-8") as stream:
+        data = yaml.safe_load(stream) or {}
+
+    if not isinstance(data, Mapping):
+        raise ValueError("plugins.yaml must define a mapping at the top level")
+
+    return data
+
+
+def _resolve_deepcode_config(config: Mapping[str, Any]) -> dict[str, Any]:
+    """Extract the DeepCode configuration mapping from the overall config."""
+
+    plugins = config.get("plugins", {})
+    if not isinstance(plugins, Mapping):
+        return {}
+
+    deepcode = plugins.get("deepcode", {})
+    if not isinstance(deepcode, Mapping):
+        return {}
+
+    return dict(deepcode)
+
+
+@router.post("/plugins/deepcode/build", response_model=DeepCodeBuildResponse)
+def build_deepcode(request: DeepCodeBuildRequest) -> DeepCodeBuildResponse:
+    """Build a DeepCode workspace from the provided source description."""
+
+    config = _resolve_deepcode_config(_load_plugins_config())
+    if not config.get("enabled"):
+        raise HTTPException(status_code=503, detail="DeepCode plugin is disabled")
+
+    adapter = DeepCodeAdapter(config)
+    result = adapter.build_from_source(request.source)
+    if not isinstance(result, Mapping):
+        raise ValueError("DeepCode adapter must return a mapping")
+
+    return DeepCodeBuildResponse(**result)
+
+
+__all__ = ["router"]

--- a/server/main.py
+++ b/server/main.py
@@ -4,7 +4,15 @@ from fastapi import FastAPI
 
 from .orchestrator.prefs import OrchestratorPrefs, get_prefs, set_prefs
 
+try:  # Import is optional to avoid hard dependency on plugin routes.
+    from api.routes.plugins import router as plugins_router
+except ModuleNotFoundError:  # pragma: no cover - defensive for optional wiring
+    plugins_router = None
+
 app = FastAPI(title="NAESTRO Server")
+
+if plugins_router and getattr(plugins_router, "routes", None):
+    app.include_router(plugins_router)
 
 
 @app.get("/orchestrator/prefs", response_model=OrchestratorPrefs)

--- a/server/tests/test_plugin_routes.py
+++ b/server/tests/test_plugin_routes.py
@@ -1,0 +1,55 @@
+import importlib
+import sys
+from pathlib import Path
+
+import yaml
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+def _reload_plugins_module():
+    return importlib.reload(importlib.import_module("api.routes.plugins"))
+
+
+def _client():
+    module = importlib.reload(importlib.import_module("server.main"))
+    return TestClient(module.app)
+
+
+def test_deepcode_route_disabled_returns_503():
+    _reload_plugins_module()
+    client = _client()
+    response = client.post("/plugins/deepcode/build", json={"source": {"branch": "main"}})
+    assert response.status_code == 503
+    assert response.json() == {"detail": "DeepCode plugin is disabled"}
+
+
+def test_deepcode_route_enabled(tmp_path, monkeypatch):
+    module = _reload_plugins_module()
+    config_path = tmp_path / "plugins.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "plugins": {
+                    "deepcode": {
+                        "enabled": True,
+                        "repo_dir": "/tmp/project",
+                        "notes": "testing",
+                    }
+                }
+            }
+        )
+    )
+    monkeypatch.setattr(module, "CONFIG_PATH", config_path)
+    client = _client()
+
+    payload = {"source": {"commit": "abc123"}}
+    response = client.post("/plugins/deepcode/build", json=payload)
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "not_wired"
+    assert body["message"] == "DeepCode adapter is not wired yet"
+    assert body["source"] == payload["source"]


### PR DESCRIPTION
## Summary
- add a FastAPI router under api/routes that reads configs/plugins.yaml and invokes the DeepCode adapter through /plugins/deepcode/build
- conditionally include the plugin router in the main FastAPI app so existing deployments without plugin wiring continue to run
- cover the new endpoint with tests for both disabled and enabled DeepCode configurations

## Testing
- pytest server/tests

------
https://chatgpt.com/codex/tasks/task_b_68ccc3ca1b00832aa7e7e657962d1f30