### PR TITLE
Add DeepCode adapter placeholder test

### DIFF
--- a/tests/plugins/test_deepcode_adapter.py
+++ b/tests/plugins/test_deepcode_adapter.py
@@ -1,0 +1,17 @@
+"""Tests for the DeepCode adapter placeholder implementation."""
+
+from integrations.plugins.deepcode_adapter import DeepCodeAdapter
+
+
+def test_build_from_source_returns_placeholder_response():
+    """The stub should emit the documented placeholder response."""
+    adapter = DeepCodeAdapter({"token": "dummy"})
+    source = {"branch": "main"}
+
+    result = adapter.build_from_source(source)
+
+    assert adapter.config == {"token": "dummy"}
+    assert set(result) == {"status", "message", "source"}
+    assert result["status"] == "not_wired"
+    assert result["message"] == "DeepCode adapter is not wired yet"
+    assert result["source"] == source


### PR DESCRIPTION
## Summary
- add unit test covering the DeepCode adapter stub response shape

## Testing
- pytest tests/plugins/test_deepcode_adapter.py

------
https://chatgpt.com/codex/tasks/task_b_68ccc6effca8832aa46ed5c774114fae