### PR TITLE
Document DeepCode plugin lane references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented here. This project adhere
 
 ## [Unreleased]
 
+- Added: **docs/plugins/deepcode.md** describing the DeepCode plugin lane integration plan.
+- Added: README Plugins / Lanes entry linking to the DeepCode lane documentation.
+- Documented: DeepCode lane status remains blocked until the adapter is wired to clarify availability expectations.
 - Added: AgentScope runtime listing docs + Mermaid diagram.
 - Added: Adapter/config stub for AgentScope integrations.
 - Updated: **VISION.md** with Engineering Quality, Meta-Cognition, Ecosystem, and Governance sections

--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ Spec and scaffolding guidance in [VS Code Extension](docs/VS_CODE_EXTENSION.md).
   - [Catalog](https://flowtemplate.com/workflows) · [Overview](https://flowtemplate.com/) · [Guide](https://flowtemplate.com/guide)
   - ℹ️ FlowTemplate module backlog updates live in [ROADMAP.md §11](./ROADMAP.md#11-filemodule-backlog) (connectors, converters, sanitizers, evaluators, studio import components).
 
+## Plugins / Lanes
+
+- [DeepCode lane](docs/plugins/deepcode.md) — Researcher→Coder→Reviewer→Runner auto-pipeline that ingests research artifacts/specs, drafts architecture plans, scaffolds code + tests, runs regression suites, and emits policy-compliant PRs for human-in-the-loop merge.
+
 ---
 
 ## ✨ Features


### PR DESCRIPTION
## Summary
- add a Plugins / Lanes callout in the README that links to the DeepCode lane documentation
- note the new DeepCode plugin lane documentation and README update in the changelog

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_b_68ccc8727374832a9fb5dcd033a906be