### PR TITLE
Document deterministic inference guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented here. This project adhere
 
 ## [Unreleased]
 
+- Documented: **docs/engineering/determinism.md** detailing the deterministic inference guard for GPU workloads.
+- Documented: Runtime toggle `runtime.determinism.guard_enabled` / `NAESTRO_DETERMINISTIC_GUARD` for enabling the guard.
+- Documented: Golden and canary evaluation flagging that forces deterministic inference during guard-protected runs.
+- Documented: CI hints directing contributors to keep the deterministic guard enabled for local checks.
+- Documented: Regression tests that compare logits/hash digests to confirm the guard's determinism guarantees.
+
 - Added: **docs/plugins/deepcode.md** describing the DeepCode plugin lane integration plan.
 - Added: README Plugins / Lanes entry linking to the DeepCode lane documentation.
 - Documented: DeepCode lane status remains blocked until the adapter is wired to clarify availability expectations.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -868,6 +868,7 @@ interventions, and instrumented explanations aligned to Phase U goals.
 - **Coverage:** 100% branch coverage (excl. bootstrap).
 - **Static checks:** mypy, ESLint, Semgrep/Bandit, IaC lint.
 - **Tests:** Unit, property, metamorphic, golden prompt suites.
+- **Determinism:** Guard enforces deterministic inference for golden and canary suites.
 - **Truthfulness CI:** fail on citation/CoVe regression.
 - **REFRAG CI:** block merges on latency/accuracy regressions.
 - **Policy CI:** stability & efficiency thresholds enforced.

--- a/docs/engineering/determinism.md
+++ b/docs/engineering/determinism.md
@@ -1,0 +1,28 @@
+# Deterministic Inference Guard
+
+The deterministic inference guard pins runtime behavior so that model outputs are reproducible across runs, GPU hosts, and CI jobs. It is designed to make golden and canary evaluation suites reliable by removing the non-determinism introduced by random number generation and GPU kernels.
+
+## Seeding Strategy
+
+- Seeds Python `random`, NumPy, and PyTorch generators from a stable scenario hash (request id + model revision).
+- Calls `torch.manual_seed()`/`torch.cuda.manual_seed_all()` on guard entry and replays the seed before every batch to stop drift over long-running jobs.
+- Resets generator state after guard exit so that non-deterministic runs remain unaffected.
+
+## cuDNN/cuBLAS Controls
+
+- Forces deterministic algorithm selection with `torch.use_deterministic_algorithms(True)` and `torch.backends.cudnn.deterministic = True`.
+- Disables cuDNN benchmarking (`torch.backends.cudnn.benchmark = False`) and TF32 fast paths (`torch.backends.cuda.matmul.allow_tf32 = False`).
+- Sets `CUBLAS_WORKSPACE_CONFIG` to `:4096:8` when initializing CUDA contexts to stabilize GEMM ordering.
+
+## Runtime Configuration Toggle
+
+- Exposed via `runtime.determinism.guard_enabled` in service configuration and the `NAESTRO_DETERMINISTIC_GUARD=1` environment variable.
+- The guard defaults to **on** for production inference. Operators can disable it for exploratory runs by setting the toggle to `false` or exporting `NAESTRO_DETERMINISTIC_GUARD=0`.
+- When disabled the guard logs a structured warning so that CI pipelines and dashboards can flag non-deterministic jobs.
+
+## Evaluation Suite Integration
+
+- Golden and canary suites force-enable the guard and emit a failing check if it is bypassed.
+- Canary runs pin all evaluation seeds by calling the guard prior to dataset preparation, guaranteeing reproducible prompt sampling.
+- CI hints remind contributors to run the suites with `NAESTRO_DETERMINISTIC_GUARD=1` so local results mirror the pipeline.
+- Regression tests exercise deterministic toggling by asserting identical logits/hash digests across repeat runs when the guard is active.


### PR DESCRIPTION
## Summary
- add deterministic inference guard documentation covering seeds, CUDA settings, runtime toggles, and evaluation hooks
- note the guard in the always-on engineering quality gates roadmap section
- extend the unreleased changelog entries with determinism guard, runtime toggle, evaluation flag, CI hint, and regression test bullets

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_b_68cce909c394832ab429594da4daba9c