### PR TITLE
Set PYTHONHASHSEED for Python CI jobs

### DIFF
--- a/.github/workflows/ci-full-and-smoke.yml
+++ b/.github/workflows/ci-full-and-smoke.yml
@@ -56,6 +56,9 @@ jobs:
 
   py_smoke:
     runs-on: ubuntu-latest
+    env:
+      PYTHONHASHSEED: "0"
+      # GPU runners must also export CUBLAS_WORKSPACE_CONFIG=:4096:8
     steps:
       - uses: actions/checkout@v5
       - name: Sanitize proxy env (global)
@@ -141,6 +144,9 @@ jobs:
 
   py_full:
     runs-on: ubuntu-latest
+    env:
+      PYTHONHASHSEED: "0"
+      # GPU runners must also export CUBLAS_WORKSPACE_CONFIG=:4096:8
     steps:
       - uses: actions/checkout@v5
       - name: Sanitize proxy env (global)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,9 @@ jobs:
       #     fail_ci_if_error: true
   python:
     runs-on: ubuntu-latest
+    env:
+      PYTHONHASHSEED: "0"
+      # GPU runners must also export CUBLAS_WORKSPACE_CONFIG=:4096:8
     steps:
       - uses: actions/checkout@v5
       - name: Sanitize proxy env (global)

--- a/.github/workflows/dep-verify.yml
+++ b/.github/workflows/dep-verify.yml
@@ -65,6 +65,9 @@ jobs:
     defaults:
       run:
         shell: bash
+    env:
+      PYTHONHASHSEED: "0"
+      # GPU runners must also export CUBLAS_WORKSPACE_CONFIG=:4096:8
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -70,6 +70,9 @@ jobs:
       #     fail_ci_if_error: true
   python:
     runs-on: ubuntu-latest
+    env:
+      PYTHONHASHSEED: "0"
+      # GPU runners must also export CUBLAS_WORKSPACE_CONFIG=:4096:8
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6


### PR DESCRIPTION
## Summary
- export `PYTHONHASHSEED=0` in every Python job across the CI workflows to keep hashing deterministic
- note that GPU runners must also export `CUBLAS_WORKSPACE_CONFIG=:4096:8`

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68cce9975434832aa53a024ea2d59d0e