### PR TITLE
Add Contains Agents reference to agent runtimes list

### DIFF
--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -162,6 +162,7 @@ docs. Keep it authoritative and in sync with `ROADMAP.md`. For collaboration mod
 - **LangGraph** — <https://github.com/langchain-ai/langgraph>
 - **CrewAI** — <https://github.com/joaomdmoura/crewai>
 - **AgentScope** — [AgentScope]
+- **Contains Agents** — <https://github.com/contains-studio/agents>
 - **AutoGen** — <https://github.com/microsoft/autogen>
 - **SuperAGI** — <https://github.com/TransformerOptimus/SuperAGI>
 - **AutoAgent (clustered swarms)** — <https://github.com/Link-AGI/AutoAgents>


### PR DESCRIPTION
## Summary
- add the Contains Agents project to the Agent Runtimes / Frameworks & Interop section of `REFERENCES.md`

## Testing
- not run (docs-only change)


------
https://chatgpt.com/codex/tasks/task_b_68cceb7443cc832ab4024ceb3fd6ff8a