### PR TITLE
Add Contains Agents runtime to roadmap integrations

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -227,6 +227,7 @@ flowchart TB
     OCA[Open Computer Agent (Browser/UI)]
     LMCache[LMCache / NIXL KV-Transfer]
     AgentScope[AgentScope Runtime]
+    ContainsAgents[Contains Agents Runtime]
     GraphRAG[GraphRAG / LazyGraphRAG]
     Firecrawl[Firecrawl (Web Crawl & Extract)]
     Gitingest[Gitingest (Repo → Digest)]
@@ -282,6 +283,7 @@ flowchart TB
   OCA --> Agents
   LMCache --> Engines
   AgentScope --> Core
+  ContainsAgents --> Core
   GraphRAG --> Memory
   Firecrawl --> Evidence
   Gitingest --> Evidence


### PR DESCRIPTION
## Summary
- add the Contains Agents runtime node to the Integrations mermaid diagram in the roadmap
- connect the Contains Agents adapter to the Core alongside other runtime integrations

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_b_68ccecf575cc832a8780f1a3faab6f89