### PR TITLE
Add Agent Companion alignment to roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -166,6 +166,7 @@ flowchart TB
     Registry[Tool/Skill Registry]
     Memory[Memory Fabric]
     Evaluators[Evaluators]
+    AgentCompanion[Agent Companion Benchmarks]
     Verifier[Claim Verifier (CoVe/Abstain)]
     Introspector[Introspector]
     SelfPR[Self-PR Bot]
@@ -249,6 +250,7 @@ flowchart TB
   Agents --> Engines
   Agents --> Memory
   Evaluators --> Verifier
+  Evaluators --> AgentCompanion
   Verifier --> Evidence
   Introspector --> SelfPR
   SelfPR --> Studio
@@ -612,7 +614,7 @@ regimes on H100/next-gen accelerators.
 
 ## 9) Observability & Metrics (OTel + Prometheus)
 
-Evaluator metric design builds on [Statistical Methods in Generative AI].
+Evaluator metric design builds on [Statistical Methods in Generative AI]. Instrumentation maintains Agent Companion alignment so benchmark traces map cleanly into the Kaggle reference dashboards.
 
 Every LLM span must include:
 


### PR DESCRIPTION
## Summary
- note Agent Companion alignment sentence in the Observability & Metrics section
- add Agent Companion Benchmarks node to the core mermaid map linked from Evaluators

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68ccf2fc7820832a9c10400fedaaae7d