### PR TITLE
Add disabled agent companion evaluator config

### DIFF
--- a/configs/evals.yaml
+++ b/configs/evals.yaml
@@ -1,6 +1,9 @@
 defaults:
   deterministic: false
 
+includes:
+  - configs/evaluators/agent_companion.yaml
+
 datasets:
   - name: InfoSeek
     description: >-

--- a/configs/evaluators/agent_companion.yaml
+++ b/configs/evaluators/agent_companion.yaml
@@ -1,0 +1,13 @@
+agent_companion:
+  enabled: false
+  suites:
+    placeholder_smoke:
+      description: >-
+        Placeholder entry for future Agent Companion smoke evaluations.
+      datasets: []
+      deterministic: false
+    placeholder_regression:
+      description: >-
+        Placeholder entry for future Agent Companion regression coverage.
+      datasets: []
+      deterministic: false


### PR DESCRIPTION
## Summary
- add a placeholder agent companion evaluator configuration file that defaults to disabled
- include the new agent companion evaluator file from the evals configuration without enabling any suites

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68ccf36f4da8832aaed7241ab560f6ce