### PR TITLE
Add test to validate agent companion evaluator config

### DIFF
--- a/tests/evaluators/test_agent_companion_config.py
+++ b/tests/evaluators/test_agent_companion_config.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+import yaml
+
+
+CONFIG_PATH = Path("configs/evaluators/agent_companion.yaml")
+
+
+def test_agent_companion_config_disabled():
+    assert CONFIG_PATH.exists(), f"Config file not found: {CONFIG_PATH}"
+
+    config = yaml.safe_load(CONFIG_PATH.read_text())
+
+    assert config["agent_companion"]["enabled"] is False


### PR DESCRIPTION
## Summary
- add a test ensuring the agent companion evaluator config exists
- verify the config is currently disabled to match expectations

## Testing
- pytest tests/evaluators/test_agent_companion_config.py


------
https://chatgpt.com/codex/tasks/task_b_68ccf3ffbf20832aa180d32f6203c766