### PR TITLE
Update changelog for Agent Companion roadmap updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented here. This project adhere
 - Documented: Golden and canary evaluation flagging that forces deterministic inference during guard-protected runs.
 - Documented: CI hints directing contributors to keep the deterministic guard enabled for local checks.
 - Documented: Regression tests that compare logits/hash digests to confirm the guard's determinism guarantees.
+- Documented: **ROADMAP.md** Agent Companion alignment note tying evaluator instrumentation back to Kaggle benchmarks.
 
 - Added: **docs/plugins/deepcode.md** describing the DeepCode plugin lane integration plan.
 - Added: README Plugins / Lanes entry linking to the DeepCode lane documentation.
@@ -19,8 +20,12 @@ All notable changes to this project will be documented here. This project adhere
 - Updated: **README.md**, **ROADMAP.md**, and **REFERENCES.md** with Contains Agents runtime coverage.
 - Added: Runtime toggle for Contains Agents integrations in **configs/runtimes.yaml**.
 - Added: Contains Agents runtime adapter stub in **integrations/runtimes/contains_agents_adapter.py**.
+- Added: **REFERENCES.md** entry capturing the Agent Companion Kaggle whitepaper reference.
+- Added: Disabled Agent Companion evaluator stub in **configs/evaluators/agent_companion.yaml** (defaulted off).
+- Added: Placeholder Agent Companion smoke suite in **configs/evaluators/agent_companion.yaml** for future coverage.
 - Updated: **VISION.md** with Engineering Quality, Meta-Cognition, Ecosystem, and Governance sections
 - Updated: cross-links in README/ROADMAP; added reference anchors
+- Updated: **ROADMAP.md** Orchestrator Mermaid map to surface the Agent Companion benchmarking lane.
 - Updated: **docs/usecases/agency_automation.md** outlining the Agency Automation flow, rollout plan, and KPIs
 - Updated: **ROADMAP.md** “What’s new” section with the REFRAG long-context acceleration lane and Naestro integration notes
 - Updated: **REFERENCES.md** to capture the latest REFRAG, SmolHub, and Qwen3-Next citations for roadmap alignment


### PR DESCRIPTION
## Summary
- log the new Agent Companion roadmap alignment note in the unreleased changelog
- record the Agent Companion reference, disabled evaluator stub, and smoke suite additions
- mention the Orchestrator Mermaid map update in the changelog

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_b_68ccf46e8630832abf1b66b125161d1d