### PR TITLE
Add tests for RLLM policy configuration and adapter exports

### DIFF
--- a/tests/policy/test_rllm_adapter_import.py
+++ b/tests/policy/test_rllm_adapter_import.py
@@ -1,0 +1,19 @@
+from integrations.policy.rllm_ppo_adapter import (
+    PPOParams,
+    RewardWeights,
+    RouterEnv,
+    RouterPPOAdapter,
+    SimpleCategoricalPolicy,
+    compute_reward,
+    ppo_train,
+)
+
+
+def test_adapter_symbols_available() -> None:
+    assert PPOParams is not None
+    assert RewardWeights is not None
+    assert RouterEnv is not None
+    assert SimpleCategoricalPolicy is not None
+    assert RouterPPOAdapter is not None
+    assert callable(compute_reward)
+    assert callable(ppo_train)

--- a/tests/policy/test_rllm_config.py
+++ b/tests/policy/test_rllm_config.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+import yaml
+
+
+CONFIG_PATH = Path(__file__).resolve().parents[2] / "configs" / "policy" / "rllm.yaml"
+
+
+def test_rllm_config_disabled_by_default() -> None:
+    config = yaml.safe_load(CONFIG_PATH.read_text())
+    assert config, "RLLM configuration should not be empty"
+    assert "rllm" in config, "RLLM configuration block missing"
+
+    rllm_config = config["rllm"]
+    assert isinstance(rllm_config, dict)
+    assert rllm_config.get("enabled") is False


### PR DESCRIPTION
## Summary
- add a regression test that loads the RLLM policy config and asserts it is disabled by default
- add a unit test that imports the RLLM PPO adapter symbols to ensure they stay available

## Testing
- pytest tests/policy -q

------
https://chatgpt.com/codex/tasks/task_b_68ccfa3844ec832aa4af6914c546da94