### PR TITLE
Add disabled mlabonne dataset registry scaffolding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be documented here. This project adhere
 - Updated: **docs/usecases/agency_automation.md** outlining the Agency Automation flow, rollout plan, and KPIs
 - Updated: **ROADMAP.md** “What’s new” section with the REFRAG long-context acceleration lane and Naestro integration notes
 - Updated: **REFERENCES.md** to capture the latest REFRAG, SmolHub, and Qwen3-Next citations for roadmap alignment
+- Added: Disabled mlabonne/llm-datasets registry scaffolding (config, helper, docs, tests) to capture dataset governance gates.
 
 - Updated: **REFERENCES.md** to include the Ling-flash-2.0 and InfoSeek research citations
 - Updated: **ROADMAP.md** with Ling-flash-2.0 milestones and InfoSeek evaluation checkpoints

--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -44,6 +44,7 @@ docs. Keep it authoritative and in sync with `ROADMAP.md`. For collaboration mod
 [Magistral Docs]: REFERENCES.md#models--architectures
 [InfoSeek]: REFERENCES.md#datasets
 [InfoSeek Framework]: REFERENCES.md#datasets
+[LLMDatasets]: REFERENCES.md#datasets
 [AgentScope]: https://github.com/agentscope-ai/agentscope
 [DeepCode]: https://github.com/HKUDS/DeepCode
 
@@ -104,6 +105,9 @@ docs. Keep it authoritative and in sync with `ROADMAP.md`. For collaboration mod
 - **SpatialVID** — _A Large-Scale Video Dataset with Spatial Annotations_ (NJU-3DV, 2025). ~7K hours
   of video with annotations: camera pose, depth maps, dynamic object masks, scene text descriptions
   (camera, motion trends, summary). Project — <https://nju-3dv.github.io/projects/SpatialVID>
+- **[LLM Datasets Aggregator][LLMDatasets]** — Curated index of SFT, alignment, agent/function
+  calling corpora, plus supporting tooling notes maintained by Maxime Labonne. Repo —
+  <https://github.com/mlabonne/llm-datasets>
 - **[InfoSeek][InfoSeek]** — _Open Data Synthesis For Deep Research_ (Ziyi Xia et al., 2025). Hierarchical constraint-satisfaction tasks (50K train, curated eval, reject-sampled trajectories) that stress deep research planning and BrowseComp-Plus benchmarking. Paper — <https://arxiv.org/abs/2509.00375>
 - **[InfoSeek Framework][InfoSeek Framework]** — Dual-agent synthesis stack that mines entities/relations, constructs research trees, and emits meta-tagged question decompositions for compound reward design. Code — <https://github.com/VectorSpaceLab/InfoSeek>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,6 +15,9 @@ _This roadmap follows the long-term direction in [Naestro VISION](./VISION.md)._
 - **Naestro integration** — Naestro exposes REFRAG through the dedicated REFRAG Controller coupled
   with vLLM/TensorRT-LLM serving adapters so orchestrated agents can transparently benefit from
   accelerated long-context inference.
+- **LLM dataset registry stub** — `configs/datasets/llm_datasets.yaml` documents the
+  [mlabonne/llm-datasets][LLMDatasets] catalog with disabled-by-default toggles, governance
+  checklists, and plan templates so ingestion only proceeds after legal review.
 
 ## North Star
 
@@ -895,6 +898,9 @@ interventions, and instrumented explanations aligned to Phase U goals.
 - `evaluators/vision_grounding/*` (IoU, similarity thresholds, tests)
 - `studio/components/vision-citation/*` (UI overlay for boxes/masks)
 - `fusion/datasets/spatialvid/*` (benchmark loaders, evaluation harness for pose/depth/masks)
+- `configs/datasets/llm_datasets.yaml` ([mlabonne/llm-datasets][LLMDatasets] catalog toggle; stay disabled until governance &
+  licensing sign-off completes)
+- `integrations/datasets/llm_datasets_registry.py` (plan/export helper that keeps mlabonne catalog interactions manual-only)
 - `refrag/encoder_service/*` (REFRAG encoder service components for compression/expansion)
 - `refrag/policy/*` (reinforcement learning policy modules for routing/optimization)
 - `refrag/adapters/vllm/*` (vLLM adapter wiring REFRAG into serving stack)
@@ -966,6 +972,7 @@ interventions, and instrumented explanations aligned to Phase U goals.
 [Nango]: REFERENCES.md#tooling--connectors--protocols
 [Ling-flash-2.0]: REFERENCES.md#models--architectures
 [Ling-flash-2.0 Paper]: REFERENCES.md#models--architectures
+[LLMDatasets]: REFERENCES.md#datasets
 [InfoSeek]: REFERENCES.md#datasets
 [InfoSeek Framework]: REFERENCES.md#datasets
 [RAG’s Biggest Lie]: REFERENCES.md#ref-rags-biggest-lie

--- a/configs/datasets/llm_datasets.yaml
+++ b/configs/datasets/llm_datasets.yaml
@@ -1,0 +1,119 @@
+llm_datasets:
+  enabled: false
+  notes: >-
+    Curated catalog seeded from the mlabonne/llm-datasets project. The registry ships
+    disabled because sourcing, licensing, and governance reviews must be completed
+    before Naestro agents can act on any of the datasets that are referenced here.
+  categories:
+    - id: general_purpose
+      title: General-purpose SFT mixtures
+      summary: >-
+        Balanced instruction-following corpora spanning chat, reasoning, code, and math
+        tasks. Use these mixtures when you need broadly capable assistants.
+      sources:
+        - name: Infinity-Instruct
+          url: https://huggingface.co/datasets/BAAI/Infinity-Instruct
+          size: "≈7.5M samples"
+          license: CC-BY-SA-4.0
+          reference: mlabonne/llm-datasets — General-purpose mixtures table
+        - name: open-perfectblend
+          url: https://huggingface.co/datasets/mlabonne/open-perfectblend
+          size: "≈1.4M samples"
+          license: Apache-2.0
+          reference: mlabonne/llm-datasets — General-purpose mixtures table
+    - id: math_reasoning
+      title: Mathematical reasoning
+      summary: >-
+        High-rationale math corpora that stress symbolic reasoning, solutions with
+        justifications, and scratchpad workflows.
+      sources:
+        - name: OpenMathInstruct-2
+          url: https://huggingface.co/datasets/nvidia/OpenMathInstruct-2
+          size: "≈14M samples"
+          license: Apache-2.0
+          reference: mlabonne/llm-datasets — Math table
+        - name: NuminaMath-CoT
+          url: https://huggingface.co/datasets/AI-MO/NuminaMath-CoT
+          size: "≈859k samples"
+          license: Apache-2.0
+          reference: mlabonne/llm-datasets — Math table
+    - id: code_generation
+      title: Code generation and repair
+      summary: >-
+        Program synthesis, translation, and debugging corpora to adapt Naestro coders
+        and tool-use agents for software automation scenarios.
+      sources:
+        - name: opc-sft-stage2
+          url: https://huggingface.co/datasets/OpenCoder-LLM/opc-sft-stage2
+          size: "≈436k samples"
+          license: MIT
+          reference: mlabonne/llm-datasets — Code table
+        - name: CodeFeedback-Filtered-Instruction
+          url: https://huggingface.co/datasets/m-a-p/CodeFeedback-Filtered-Instruction
+          size: "≈157k samples"
+          license: Apache-2.0
+          reference: mlabonne/llm-datasets — Code table
+    - id: agentic_tooling
+      title: Agent & function-calling corpora
+      summary: >-
+        Structured output datasets that teach models to emit JSON/function call payloads
+        for downstream agents, workflows, and API integrations.
+      sources:
+        - name: hermes-function-calling-v1
+          url: https://huggingface.co/datasets/NousResearch/hermes-function-calling-v1
+          size: "≈11.6k samples"
+          license: Apache-2.0
+          reference: mlabonne/llm-datasets — Agent & Function calling table
+        - name: ToolACE
+          url: https://huggingface.co/datasets/Team-ACE/ToolACE
+          size: "≈11.3k samples"
+          license: Apache-2.0
+          reference: mlabonne/llm-datasets — Agent & Function calling table
+    - id: preference_alignment
+      title: Preference alignment
+      summary: >-
+        Chosen vs. rejected answer pairs for reward modeling, DPO, ORPO, and related
+        preference-learning techniques.
+      sources:
+        - name: Skywork-Reward-Preference-80K-v0.2
+          url: https://huggingface.co/datasets/Skywork/Skywork-Reward-Preference-80K-v0.2
+          size: "≈77k preference pairs"
+          license: Unknown — review dataset card before use
+          reference: mlabonne/llm-datasets — Preference alignment table
+        - name: ultrafeedback-binarized-preferences-cleaned
+          url: https://huggingface.co/datasets/argilla/ultrafeedback-binarized-preferences-cleaned
+          size: "≈61k preference pairs"
+          license: Apache-2.0
+          reference: mlabonne/llm-datasets — Preference alignment table
+  usage:
+    activation_steps:
+      - Review the mlabonne/llm-datasets README to confirm dataset freshness, licensing,
+        and curation notes.
+      - Complete internal data governance review and document consent/data handling
+        policies for every dataset before toggling `enabled` to true.
+      - Wire ingestion jobs (Hugging Face CLI, parquet snapshots, or data lake sync) and
+        register resulting artifacts in Naestro's evidence store.
+    plan_template:
+      summary: >-
+        When the registry is enabled, agents can draft ingestion or fine-tuning plans for a
+        given category by expanding this template.
+      steps:
+        - Validate licensing and usage restrictions with legal/compliance stakeholders.
+        - Stage the dataset in an isolated workspace with checksum validation.
+        - Run deduplication and safety filters (refusals, PII, policy violations).
+        - Emit a Naestro `Plan.json` proposal summarizing costs, tooling, and evaluators.
+  legal:
+    compliance_gates:
+      - The registry is informational. Each dataset requires explicit approval from the
+        Naestro governance process before it can be downloaded or used in training.
+      - Datasets that include personal data or sensitive content demand privacy impact
+        assessments and data minimization controls.
+    restrictions:
+      - Licenses vary widely (Apache, MIT, CC, research-only). Never assume rights transfer—
+        confirm each dataset's license and attribution requirements directly from the
+        upstream card or repository.
+      - Some datasets contain model-generated content with potential bias, toxicity, or
+        safety hazards. Apply evaluators and guardrails prior to production use.
+    contacts:
+      - Data Governance: datagovernance@example.com
+      - Legal Review: legal@example.com

--- a/docs/datasets/llm_datasets.md
+++ b/docs/datasets/llm_datasets.md
@@ -1,0 +1,81 @@
+# LLM Datasets Registry (mlabonne/llm-datasets)
+
+The mlabonne/llm-datasets project curates a living index of post-training
+corpora—covering supervised fine-tuning (SFT), reward modeling, agent/function
+calling, and tooling to ingest or filter data. Naestro ships a **disabled**
+registry wrapper so operators can document intent while ensuring no automated
+job accesses external datasets without explicit governance approval.
+
+## Configuration layout
+
+- **File:** `configs/datasets/llm_datasets.yaml`
+- **Default state:** `enabled: false`
+- **Structure:**
+  - `notes` — operator context that explains why the registry remains disabled.
+  - `categories` — curated groupings (general-purpose SFT, math, code, agentic
+    tooling, preference alignment) with representative datasets and license
+    hints pulled from mlabonne/llm-datasets.
+  - `usage.activation_steps` — manual checklist for refreshing the catalog,
+    running ingestion, and registering artifacts inside Naestro.
+  - `usage.plan_template` — reusable step list for generating a Naestro
+    `Plan.json` once legal and data governance sign off.
+  - `legal` — compliance, restriction, and contact notes that must remain
+    satisfied before the switch can be flipped.
+
+Because the registry is informational, **never** toggle `enabled: true` until
+legal, privacy, and data governance stakeholders complete their reviews for
+_every dataset_ you plan to ingest.
+
+## Python helper
+
+`integrations/datasets/llm_datasets_registry.py` exposes a lightweight helper to
+inspect the configuration and draft plans without enabling automated access.
+
+```python
+from pathlib import Path
+
+from integrations.datasets.llm_datasets_registry import (
+    LLMDatasetsRegistry,
+    load_registry,
+)
+
+# Load the disabled-by-default registry
+registry = load_registry()
+print("Registry enabled?", registry.enabled)
+print("Available categories:", registry.list_categories())
+
+# Draft a Plan.json stub for offline review
+plan_stub = registry.create_plan("general_purpose")
+export_path = Path("/tmp/llm-datasets-plan.json")
+registry.export_plan("general_purpose", export_path)
+```
+
+`create_plan` and `export_plan` mirror the template stored in the YAML file and
+always emit a `status: disabled` payload until the configuration is updated.
+They are intentionally conservative: the helper will raise a `KeyError` for
+unknown categories and never bootstrap network operations.
+
+## Operational checklist
+
+1. Review the upstream [mlabonne/llm-datasets README](https://github.com/mlabonne/llm-datasets)
+   for the datasets you intend to ingest. Validate freshness, deduplication
+   strategy, licensing, and any authorship constraints.
+2. Route the request through Naestro's data governance workflow. Document the
+   purpose of each dataset, approved storage locations, retention windows, and
+   required evaluators/guardrails.
+3. Only after sign-off, update `configs/datasets/llm_datasets.yaml` to set
+   `enabled: true`, commit the decision record, and wire ingestion automations.
+4. Monitor ingestion logs and evaluator runs. Pause the registry if quality,
+   safety, or licensing concerns surface.
+
+## Legal & compliance notice
+
+- mlabonne/llm-datasets aggregates public links but does not grant license
+  rights. You must confirm attribution, redistribution, and privacy obligations
+  directly from each dataset card or upstream repository.
+- Many corpora contain synthetic or user-generated data that can surface biases,
+  disallowed content, or personally identifiable information. Apply Naestro's
+  safety filters, anonymization tooling, and evaluator suites before deploying
+  derived models.
+- Keep legal and data governance contacts documented in the YAML file so future
+  operators know who authorized access and where to escalate questions.

--- a/integrations/datasets/llm_datasets_registry.py
+++ b/integrations/datasets/llm_datasets_registry.py
@@ -1,0 +1,155 @@
+"""Disabled-by-default registry helper for the mlabonne/llm-datasets catalog."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+_CONFIG_PATH = Path(__file__).resolve().parents[2] / "configs" / "datasets" / "llm_datasets.yaml"
+
+
+class LLMDatasetsRegistry:
+    """Helper around the curated mlabonne/llm-datasets configuration."""
+
+    def __init__(
+        self,
+        document: Mapping[str, Any] | None = None,
+        *,
+        config_path: Path | None = None,
+    ) -> None:
+        self._config_path = config_path or _CONFIG_PATH
+        raw_document = self._load_document(document)
+        self._config = self._extract_config(raw_document)
+        self._categories = self._normalise_categories(self._config.get("categories"))
+
+    def _load_document(self, document: Mapping[str, Any] | None) -> dict[str, Any]:
+        if document is not None:
+            return dict(document)
+
+        if not self._config_path.exists():
+            raise FileNotFoundError(f"Dataset registry config missing: {self._config_path}")
+        loaded = yaml.safe_load(self._config_path.read_text()) or {}
+        if not isinstance(loaded, dict):
+            raise TypeError("Dataset registry config must deserialize to a mapping")
+        return loaded
+
+    @staticmethod
+    def _extract_config(document: Mapping[str, Any]) -> dict[str, Any]:
+        if "llm_datasets" in document and isinstance(document["llm_datasets"], Mapping):
+            source = document["llm_datasets"]
+        else:
+            source = document
+        return dict(source)
+
+    @staticmethod
+    def _normalise_categories(categories: Any) -> list[dict[str, Any]]:
+        normalised: list[dict[str, Any]] = []
+        if isinstance(categories, Mapping):
+            for identifier, entry in categories.items():
+                if isinstance(entry, Mapping):
+                    data = dict(entry)
+                else:
+                    data = {"value": entry}
+                data.setdefault("id", identifier)
+                normalised.append(data)
+            return normalised
+
+        if isinstance(categories, Iterable):
+            for entry in categories:
+                if isinstance(entry, Mapping):
+                    normalised.append(dict(entry))
+        return normalised
+
+    @property
+    def enabled(self) -> bool:
+        """Return whether the registry is enabled for automated consumption."""
+
+        return bool(self._config.get("enabled"))
+
+    @property
+    def notes(self) -> str | None:
+        """Return the operator notes attached to the registry configuration."""
+
+        raw_notes = self._config.get("notes")
+        return str(raw_notes) if raw_notes is not None else None
+
+    def list_categories(self) -> list[str]:
+        """Return the category identifiers tracked in the registry."""
+
+        categories: list[str] = []
+        for entry in self._categories:
+            identifier = entry.get("id") or entry.get("title") or entry.get("name")
+            if identifier is None:
+                continue
+            categories.append(str(identifier))
+        return categories
+
+    def get_category(self, identifier: str) -> dict[str, Any]:
+        """Return metadata for a given category identifier."""
+
+        normalised = identifier.lower()
+        for entry in self._categories:
+            candidate = str(entry.get("id") or entry.get("title") or "").lower()
+            if candidate == normalised:
+                return dict(entry)
+        raise KeyError(f"Unknown dataset category: {identifier}")
+
+    def create_plan(self, identifier: str) -> dict[str, Any]:
+        """Create a disabled-by-default Naestro plan stub for the requested category."""
+
+        category = self.get_category(identifier)
+        plan_template = self._config.get("usage", {}).get("plan_template", {})
+        steps: list[Any] = []
+        template_steps = plan_template.get("steps")
+        if isinstance(template_steps, Iterable) and not isinstance(template_steps, (str, bytes)):
+            for step in template_steps:
+                steps.append(step)
+
+        sources: list[dict[str, Any]] = []
+        for source in category.get("sources", []) or []:
+            if isinstance(source, Mapping):
+                sources.append(
+                    {
+                        "name": source.get("name"),
+                        "url": source.get("url"),
+                        "license": source.get("license"),
+                        "size": source.get("size"),
+                        "reference": source.get("reference"),
+                    }
+                )
+
+        return {
+            "status": "disabled" if not self.enabled else "draft",
+            "category": category.get("id"),
+            "title": category.get("title"),
+            "summary": category.get("summary"),
+            "notes": self.notes,
+            "sources": sources,
+            "plan_template": {
+                "summary": plan_template.get("summary"),
+                "steps": steps,
+            },
+        }
+
+    def export_plan(self, identifier: str, destination: Path) -> Path:
+        """Write a category plan stub to disk as formatted JSON."""
+
+        plan = self.create_plan(identifier)
+        destination = destination.expanduser().resolve()
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_text(json.dumps(plan, indent=2, sort_keys=True))
+        return destination
+
+
+def load_registry(config_path: Path | None = None) -> LLMDatasetsRegistry:
+    """Convenience loader that returns a registry instance from disk."""
+
+    if config_path is not None:
+        document = yaml.safe_load(config_path.read_text()) or {}
+        return LLMDatasetsRegistry(document=document, config_path=config_path)
+    return LLMDatasetsRegistry()

--- a/tests/datasets/test_llm_datasets_registry.py
+++ b/tests/datasets/test_llm_datasets_registry.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+import yaml
+
+from integrations.datasets.llm_datasets_registry import LLMDatasetsRegistry
+
+
+CONFIG_PATH = Path(__file__).resolve().parents[2] / "configs" / "datasets" / "llm_datasets.yaml"
+
+
+def test_llm_datasets_config_is_disabled() -> None:
+    config = yaml.safe_load(CONFIG_PATH.read_text())
+    assert config, "LLM datasets configuration should not be empty"
+    assert "llm_datasets" in config, "llm_datasets block missing from configuration"
+
+    llm_config = config["llm_datasets"]
+    assert isinstance(llm_config, dict)
+    assert llm_config.get("enabled") is False
+
+
+def test_registry_reports_disabled_state() -> None:
+    registry = LLMDatasetsRegistry()
+    assert registry.enabled is False
+    categories = registry.list_categories()
+    assert isinstance(categories, list)
+    assert "general_purpose" in categories


### PR DESCRIPTION
## Summary
- add a disabled-by-default `configs/datasets/llm_datasets.yaml` seeded from mlabonne/llm-datasets with categories, usage notes, and legal gates
- implement the `LLMDatasetsRegistry` helper plus operator docs for plan creation/export workflows
- update roadmap, references, changelog, and add unit tests to lock the disabled state

## Testing
- pytest tests/datasets -q

------
https://chatgpt.com/codex/tasks/task_b_68cd04428c80832a9c2936d27dd6772c