### PR TITLE
Update Codex prompt paths for training package

### DIFF
--- a/docs/prompts/codex_prompt.md
+++ b/docs/prompts/codex_prompt.md
@@ -1,0 +1,43 @@
+# Codex Prompt: HICRA Credit Assignment Package
+
+## Objective
+Stand up the HICRA credit assignment training package inside the repository so
+Codex can implement and test the module end-to-end.
+
+## Project Structure
+Create the training package under `src/training/` with the following skeleton:
+
+```
+src/
+  training/
+    __init__.py
+    hicra.py
+```
+
+The tests for the assigner should live alongside the other unit suites, e.g.
+`tests/training/test_hicra.py`.
+
+## Implementation Notes
+- Expose the main entry point as `HICRACreditAssigner` inside
+  `src/training/hicra.py`.
+- Update any existing references so Codex always imports the class with:
+
+  ```python
+  from src.training.hicra import HICRACreditAssigner
+  ```
+
+- Build lightweight fixtures so tests can instantiate the assigner without
+  orchestrator dependencies.
+
+## TODO / Integration Follow-Ups
+- When orchestrator support is ready, thread the trained assigner into
+  `src/orchestrator/orchestrator.py` and `src/orchestrator/main.py`.
+- Document how the training outputs plug into the routers and agents under
+  `src/orchestrator/` for future automation.
+- Add integration smoke tests once the orchestrator glue code in
+  `src/orchestrator/math_agent.py` consumes the training artifacts.
+
+## Validation Checklist
+- Unit tests import `HICRACreditAssigner` from `src.training.hicra`.
+- Ensure linting passes for the new package.
+- Capture README updates if configuration steps change.


### PR DESCRIPTION
## Summary
- add a Codex guidance document that directs creation of the training package under `src/training/`
- update the example import/tests in the prompt to use `from src.training.hicra import HICRACreditAssigner`
- refresh TODO notes so future integration points reference `src/orchestrator` modules

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68cdd5439b1c832a9ae8cfa3a853328a