### PR TITLE
Document HICRA config location

### DIFF
--- a/configs/training/hicra.yaml
+++ b/configs/training/hicra.yaml
@@ -1,0 +1,7 @@
+# Default configuration for the HICRA credit assignment trainer.
+hicra:
+  enabled: false
+  notes: >-
+    Placeholder defaults for the upcoming HICRA credit assignment module.
+    Expand this configuration with datasets, optimizer settings, evaluation
+    schedules, and artifact locations as the trainer matures.

--- a/docs/prompts/codex_prompt.md
+++ b/docs/prompts/codex_prompt.md
@@ -28,6 +28,10 @@ The tests for the assigner should live alongside the other unit suites, e.g.
 
 - Build lightweight fixtures so tests can instantiate the assigner without
   orchestrator dependencies.
+- Place the trainer defaults in `configs/training/hicra.yaml` inside the
+  existing `configs/` tree. Use this real configuration file (create it in the
+  `configs/training/` directory) rather than referencing a placeholder
+  `config.yaml`.
 
 ## TODO / Integration Follow-Ups
 - When orchestrator support is ready, thread the trained assigner into


### PR DESCRIPTION
## Summary
- add a seed `configs/training/hicra.yaml` file to hold the HICRA trainer defaults
- update the Codex prompt so it directs changes to the real HICRA config path rather than `config.yaml`

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68cddbf4c6ec832aa6f11a54a2e93cde