### PR TITLE
Align HICRA config template with default options

### DIFF
--- a/configs/training/hicra.yaml
+++ b/configs/training/hicra.yaml
@@ -1,7 +1,6 @@
 # Default configuration for the HICRA credit assignment trainer.
 hicra:
-  enabled: false
-  notes: >-
-    Placeholder defaults for the upcoming HICRA credit assignment module.
-    Expand this configuration with datasets, optimizer settings, evaluation
-    schedules, and artifact locations as the trainer matures.
+  enabled: true
+  planner_weight: 1.0
+  normalize: false
+  eps: 1.0e-08

--- a/src/training/hicra.py
+++ b/src/training/hicra.py
@@ -17,13 +17,15 @@ class HICRAConfig:
     enabled:
         When ``False`` the assigner short-circuits and returns zeros.
     multiplier:
-        Scalar factor applied to the computed credits.
+        Scalar factor applied to the computed credits. Configuration files may
+        specify this value using the ``planner_weight`` key.
     normalize:
         If ``True`` the assigner normalizes the masked rewards before applying
         the multiplier.
     normalization_eps:
         Small constant added during variance computation to avoid division by
-        zero when all masked rewards are identical.
+        zero when all masked rewards are identical. Configuration files may
+        specify this value using the ``eps`` or ``epsilon`` keys.
     """
 
     enabled: bool = True
@@ -53,10 +55,23 @@ class HICRAConfig:
 
         return cls(
             enabled=bool(_maybe_get(data, "enabled", default=True)),
-            multiplier=float(_maybe_get(data, "multiplier", default=1.0)),
+            multiplier=float(
+                _maybe_get(
+                    data,
+                    "multiplier",
+                    "planner_weight",
+                    default=1.0,
+                )
+            ),
             normalize=bool(_maybe_get(data, "normalize", default=False)),
             normalization_eps=float(
-                _maybe_get(data, "normalization_eps", "epsilon", default=1e-8)
+                _maybe_get(
+                    data,
+                    "normalization_eps",
+                    "epsilon",
+                    "eps",
+                    default=1e-8,
+                )
             ),
         )
 

--- a/tests/training/test_hicra.py
+++ b/tests/training/test_hicra.py
@@ -44,3 +44,13 @@ def test_build_hicra_from_dict_handles_nested_config() -> None:
     credits = assigner(rewards)
 
     assert torch.allclose(credits, rewards * 3.0)
+
+
+def test_build_hicra_from_dict_supports_alias_keys() -> None:
+    assigner = build_hicra_from_dict(
+        {"hicra": {"planner_weight": 2.0, "normalize": True, "eps": 1e-6}}
+    )
+
+    assert assigner.config.multiplier == 2.0
+    assert assigner.config.normalize is True
+    assert assigner.config.normalization_eps == 1e-6


### PR DESCRIPTION
## Summary
- expand the HICRA training configuration template with enabled, planner_weight, normalize, and eps defaults
- allow the HICRA configuration loader to accept planner_weight and eps aliases while updating documentation
- add a unit test that exercises the new alias handling in the loader

## Testing
- pytest tests/training/test_hicra.py *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_b_68cde2b1ffd0832a9c24196ca3670431