### PR TITLE
Document HICRA credit assignment in policy guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Full curated list: https://turingpost.com/p/fod118
 - [Multi-node deployment](docs/DEPLOY_MULTI_NODE.md)
 - [Apple sidecars](docs/APPLE_MODELS.md)
 - [Integrations](docs/INTEGRATIONS.md)
+- [Policy training (RLLM + HICRA)](docs/policy/rllm.md)
 - [Graphiti Guide](docs/GRAPHITI.md)
 - [Orchestrator collaboration](docs/orchestrator_collaboration.md)
 - [Studio ↔ Core API contract](docs/UI_API_CONTRACT.md)


### PR DESCRIPTION
## Summary
- describe the HICRA credit assignment helper in the RLLM policy guide, covering enablement steps, configuration, telemetry, and workflow guidance
- add a README cross-link so the new policy training docs are easy to find

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_b_68cdea0d2bc0832a90485a393288dcdb