### PR TITLE
Pin CPU-only torch dependency

### DIFF
--- a/requirements.lock
+++ b/requirements.lock
@@ -4,14 +4,26 @@
 #
 #    pip-compile --output-file=requirements.lock requirements.txt
 #
+--extra-index-url https://download.pytorch.org/whl/cpu
+
 certifi==2025.8.3
     # via requests
 charset-normalizer==3.4.3
     # via requests
+filelock==3.19.1
+    # via torch
+fsspec==2025.9.0
+    # via torch
 idna==3.10
     # via requests
+jinja2==3.1.6
+    # via torch
+markupsafe==3.0.2
+    # via jinja2
 mpmath==1.3.0
     # via sympy
+networkx==3.5
+    # via torch
 numpy==2.3.2
     # via scipy
 pyyaml==6.0.2
@@ -21,6 +33,15 @@ requests==2.32.4
 scipy==1.16.1
     # via -r requirements.txt
 sympy==1.14.0
+    # via
+    #   -r requirements.txt
+    #   torch
+torch==2.4.1+cpu
     # via -r requirements.txt
+typing-extensions==4.15.0
+    # via torch
 urllib3==2.5.0
     # via requests
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
+--extra-index-url https://download.pytorch.org/whl/cpu
 pyyaml==6.0.2
 requests==2.32.4
 scipy==1.16.1
 sympy==1.14.0
+torch==2.4.1+cpu


### PR DESCRIPTION
## Summary
- pin the CPU-only torch wheel in `requirements.txt`
- regenerate `requirements.lock` to capture torch and its dependencies

## Testing
- `pytest -m "not slow" --cov=src --cov-report=xml --cov-report=term-missing --cov-fail-under=100` *(fails: coverage total 98 < 100)*

------
https://chatgpt.com/codex/tasks/task_b_68cdfa756224832aa81b5923ac54323c