### PR TITLE
Implement deterministic bus with schema enforcement

### DIFF
--- a/naestro/core/__init__.py
+++ b/naestro/core/__init__.py
@@ -2,16 +2,25 @@
 
 from __future__ import annotations
 
-from .bus import LoggingMiddleware, MessageBus
+from .bus import Envelope, LoggingMiddleware, MessageBus, RedactionMiddleware
 from .debate import DebateOrchestrator
 from .schemas import DebateTranscript, Message
+from .summary import BusSummary, summarize
+from .trace import TraceEvent, build_trace, write_trace
 from .tracing import Tracer
 
 __all__ = [
+    "BusSummary",
     "DebateOrchestrator",
     "DebateTranscript",
+    "Envelope",
     "LoggingMiddleware",
     "Message",
     "MessageBus",
+    "RedactionMiddleware",
+    "TraceEvent",
     "Tracer",
+    "build_trace",
+    "summarize",
+    "write_trace",
 ]

--- a/naestro/core/bus.py
+++ b/naestro/core/bus.py
@@ -1,29 +1,198 @@
-"""In-memory synchronous message bus with middleware support."""
+"""Deterministic in-memory message bus with schema enforcement."""
 
 from __future__ import annotations
 
+import json
+from contextvars import ContextVar
 from dataclasses import dataclass
-from typing import Callable, Dict, List, Protocol
+from datetime import datetime, timedelta, timezone
+from importlib import resources
+from types import MappingProxyType
+from typing import Any, Callable, Iterable, Mapping, MutableMapping, Protocol, Sequence
 
-Payload = object
+try:  # pragma: no cover - handled at runtime in MessageBus
+    import jsonschema
+except ImportError:  # pragma: no cover - lazy error in _SchemaCatalog
+    jsonschema = None  # type: ignore[assignment]
+
+Payload = dict[str, object]
+
+
+def _deep_copy(value: object) -> object:
+    if isinstance(value, Mapping):
+        return {str(key): _deep_copy(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_deep_copy(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_deep_copy(item) for item in value)
+    return value
+
+
+def _normalize_payload(payload: object) -> Payload:
+    if isinstance(payload, Mapping):
+        return {str(key): _deep_copy(value) for key, value in payload.items()}
+    raise TypeError("MessageBus payloads must be mapping-like objects")
+
+
+def _redact_path(value: object, parts: Sequence[str], replacement: object) -> bool:
+    if not parts:
+        return False
+    head, *tail = parts
+    if isinstance(value, MutableMapping):
+        if head not in value:
+            return False
+        if not tail:
+            value[head] = replacement
+            return True
+        return _redact_path(value[head], tail, replacement)
+    if isinstance(value, list):
+        try:
+            index = int(head)
+        except ValueError:
+            return False
+        if index < 0 or index >= len(value):
+            return False
+        if not tail:
+            value[index] = replacement
+            return True
+        return _redact_path(value[index], tail, replacement)
+    return False
+
+
+def _apply_redactions(
+    payload: Payload, paths: Sequence[str], replacement: object
+) -> tuple[Payload, tuple[str, ...]]:
+    if not paths:
+        return payload, ()
+    sanitized = _normalize_payload(payload)
+    applied: list[str] = []
+    for path in paths:
+        if _redact_path(sanitized, path.split("."), replacement):
+            applied.append(path)
+    return sanitized, tuple(applied)
+
+
+def _freeze_payload(payload: Payload) -> Mapping[str, object]:
+    return MappingProxyType({str(key): _deep_copy(value) for key, value in payload.items()})
+
+
+_ENVELOPE_CONTEXT: ContextVar[dict[str, list[str]] | None] = ContextVar(
+    "_ENVELOPE_CONTEXT", default=None
+)
+
+
+def _record_redactions(redactions: Iterable[str]) -> None:
+    context = _ENVELOPE_CONTEXT.get()
+    if not context:
+        return
+    context.setdefault("redactions", []).extend(redactions)
+
+
+def _load_default_schema() -> Mapping[str, Any]:
+    package = resources.files(__package__)
+    with package.joinpath("schemas.json").open("r", encoding="utf-8") as stream:
+        return json.load(stream)
+
+
+class _SchemaCatalog:
+    def __init__(self, schema: Mapping[str, Any]) -> None:
+        if jsonschema is None:  # pragma: no cover - dependency guard
+            raise RuntimeError(
+                "jsonschema is required to use the deterministic message bus"
+            )
+        if not isinstance(schema, Mapping):
+            raise TypeError("schema must be a mapping")
+        events = schema.get("events")
+        if not isinstance(events, Mapping):
+            raise ValueError("schema is missing an 'events' mapping")
+        self._schema = dict(schema)
+        self._event_schemas: dict[str, Mapping[str, Any]] = {}
+        self._validators: dict[str, jsonschema.Validator] = {}
+        resolver = jsonschema.RefResolver.from_schema(schema)
+        base_cls = jsonschema.validators.validator_for(schema)
+        base_cls.check_schema(schema)
+        self._resolver = resolver
+        for event, subschema in events.items():
+            self.register(event, subschema)
+
+    def register(self, event: str, schema: Mapping[str, Any]) -> None:
+        if jsonschema is None:  # pragma: no cover
+            raise RuntimeError(
+                "jsonschema is required to register additional event schemas"
+            )
+        if not isinstance(event, str):
+            raise TypeError("event names must be strings")
+        if not isinstance(schema, Mapping):
+            raise TypeError("event schema must be a mapping")
+        validator_cls = jsonschema.validators.validator_for(schema)
+        validator_cls.check_schema(schema)
+        validator = validator_cls(schema, resolver=self._resolver)
+        self._event_schemas[event] = dict(schema)
+        self._validators[event] = validator
+
+    def validate(self, event: str, payload: Mapping[str, object]) -> None:
+        validator = self._validators.get(event)
+        if validator is None:
+            raise KeyError(f"unknown event '{event}'")
+        validator.validate(payload)
+
+    def schema_for(self, event: str) -> Mapping[str, Any]:
+        if event not in self._event_schemas:
+            raise KeyError(f"unknown event '{event}'")
+        return self._event_schemas[event]
+
+    @property
+    def events(self) -> Sequence[str]:
+        return tuple(sorted(self._event_schemas))
+
+
+@dataclass(frozen=True, slots=True)
+class Envelope:
+    sequence: int
+    event: str
+    payload: Mapping[str, object]
+    timestamp: datetime
+    redactions: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "sequence": self.sequence,
+            "event": self.event,
+            "timestamp": self.timestamp.isoformat(),
+            "payload": json.loads(json.dumps(self.payload, default=str)),
+            "redactions": list(self.redactions),
+        }
+
+
+Forward = Callable[[str, Payload], tuple[str, Payload]]
 
 
 class Middleware(Protocol):
     def __call__(
-        self, event: str, payload: Payload, next_call: Callable[[str, Payload], None]
-    ) -> None:
-        """Process an event or pass it to the next middleware."""
+        self, event: str, payload: Payload, forward: Forward
+    ) -> tuple[str, Payload] | None:
+        ...
 
 
-Handler = Callable[[Payload], None]
+Handler = Callable[[Mapping[str, object]], None]
 
 
 class MessageBus:
-    """Simple synchronous publish/subscribe bus."""
+    """Synchronous deterministic bus backed by JSON Schema validation."""
 
-    def __init__(self) -> None:
-        self._handlers: Dict[str, List[Handler]] = {}
-        self._middleware: List[Middleware] = []
+    def __init__(
+        self,
+        *,
+        schema: Mapping[str, Any] | None = None,
+        base_timestamp: datetime | None = None,
+    ) -> None:
+        raw_schema = schema or _load_default_schema()
+        self._catalog = _SchemaCatalog(raw_schema)
+        self._handlers: dict[str, list[Handler]] = {}
+        self._middleware: list[Middleware] = []
+        self._envelopes: list[Envelope] = []
+        self._sequence = 0
+        self._base_timestamp = base_timestamp or datetime(2024, 1, 1, tzinfo=timezone.utc)
 
     def subscribe(self, event: str, handler: Handler) -> None:
         self._handlers.setdefault(event, []).append(handler)
@@ -31,41 +200,120 @@ class MessageBus:
     def use(self, middleware: Middleware) -> None:
         self._middleware.append(middleware)
 
-    def publish(self, event: str, payload: Payload) -> None:
-        def invoke_middleware(
-            index: int, current_event: str, current_payload: Payload
-        ) -> None:
-            if index < len(self._middleware):
-                middleware = self._middleware[index]
-                middleware(
-                    current_event,
-                    current_payload,
-                    lambda next_event, next_payload: invoke_middleware(
-                        index + 1, next_event, next_payload
-                    ),
-                )
-            else:
-                for handler in self._handlers.get(current_event, []):
-                    handler(current_payload)
+    def known_events(self) -> Sequence[str]:
+        return self._catalog.events
 
-        invoke_middleware(0, event, payload)
+    def register_schema(self, event: str, schema: Mapping[str, Any]) -> None:
+        self._catalog.register(event, schema)
+
+    def publish(self, event: str, payload: Mapping[str, object] | object) -> Envelope | None:
+        normalized = _normalize_payload(payload)
+        token = _ENVELOPE_CONTEXT.set({"redactions": []})
+        redactions: tuple[str, ...] = ()
+        try:
+            final_event, final_payload, forwarded = self._dispatch(0, event, normalized)
+            if not forwarded:
+                return None
+            self._catalog.validate(final_event, final_payload)
+            context = _ENVELOPE_CONTEXT.get()
+            if context:
+                redactions = tuple(context.get("redactions", []))
+            sequence = self._sequence + 1
+            self._sequence = sequence
+            timestamp = self._base_timestamp + timedelta(milliseconds=sequence)
+            frozen_payload = _freeze_payload(final_payload)
+            envelope = Envelope(
+                sequence=sequence,
+                event=final_event,
+                payload=frozen_payload,
+                timestamp=timestamp,
+                redactions=redactions,
+            )
+            self._envelopes.append(envelope)
+            for handler in self._handlers.get(final_event, []):
+                handler(envelope.payload)
+            return envelope
+        finally:
+            _ENVELOPE_CONTEXT.reset(token)
+
+    def _dispatch(
+        self, index: int, event: str, payload: Payload
+    ) -> tuple[str, Payload, bool]:
+        if index >= len(self._middleware):
+            return event, payload, True
+        forwarded = False
+        final_event = event
+        final_payload = payload
+
+        def forward(next_event: str, next_payload: Payload) -> tuple[str, Payload]:
+            nonlocal forwarded, final_event, final_payload
+            forwarded = True
+            final_event, final_payload, _ = self._dispatch(
+                index + 1, next_event, next_payload
+            )
+            return final_event, final_payload
+
+        result = self._middleware[index](event, payload, forward)
+        if result is not None:
+            forwarded = True
+            final_event, final_payload = result
+        return final_event, final_payload, forwarded
 
     def clear(self) -> None:
         self._handlers.clear()
         self._middleware.clear()
+        self._envelopes.clear()
+        self._sequence = 0
+
+    @property
+    def envelopes(self) -> Sequence[Envelope]:
+        return tuple(self._envelopes)
 
 
-@dataclass
+@dataclass(slots=True)
 class LoggingMiddleware:
     """Middleware that mirrors events into a collector callable."""
 
-    logger: Callable[[str, Payload], None]
+    logger: Callable[[str, Mapping[str, object]], None]
 
     def __call__(
-        self, event: str, payload: Payload, next_call: Callable[[str, Payload], None]
+        self, event: str, payload: Payload, forward: Forward
+    ) -> tuple[str, Payload] | None:
+        self.logger(event, MappingProxyType(dict(payload)))
+        return forward(event, payload)
+
+
+class RedactionMiddleware:
+    """Middleware that redacts configured keys from payloads."""
+
+    def __init__(
+        self,
+        rules: Mapping[str, Sequence[str]] | Sequence[str],
+        *,
+        replacement: object = "***REDACTED***",
     ) -> None:
-        self.logger(event, payload)
-        next_call(event, payload)
+        if isinstance(rules, Mapping):
+            self._rules = {str(event): tuple(paths) for event, paths in rules.items()}
+        else:
+            self._rules = {"*": tuple(rules)}
+        self._replacement = replacement
+
+    def __call__(
+        self, event: str, payload: Payload, forward: Forward
+    ) -> tuple[str, Payload] | None:
+        paths = list(self._rules.get("*", ())) + list(self._rules.get(event, ()))
+        if not paths:
+            return forward(event, payload)
+        sanitized, applied = _apply_redactions(payload, paths, self._replacement)
+        if applied:
+            _record_redactions(applied)
+        return forward(event, sanitized)
 
 
-__all__ = ["LoggingMiddleware", "MessageBus", "Middleware", "Payload"]
+__all__ = [
+    "Envelope",
+    "LoggingMiddleware",
+    "MessageBus",
+    "Middleware",
+    "RedactionMiddleware",
+]

--- a/naestro/core/schemas.json
+++ b/naestro/core/schemas.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://naestro.ai/schemas/core/bus.json",
+  "title": "Naestro core message bus schemas",
+  "description": "Event payload schemas enforced by the deterministic message bus.",
+  "$defs": {
+    "metadata": {
+      "type": "object",
+      "description": "Arbitrary metadata attached to messages.",
+      "additionalProperties": {}
+    },
+    "message": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["role", "content", "timestamp", "metadata"],
+      "properties": {
+        "role": {
+          "type": "string",
+          "minLength": 1
+        },
+        "content": {
+          "type": "string"
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "metadata": {
+          "$ref": "#/$defs/metadata"
+        }
+      }
+    }
+  },
+  "events": {
+    "debate.started": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["participants", "prompt"],
+      "properties": {
+        "participants": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "prompt": {
+          "type": "string"
+        }
+      }
+    },
+    "debate.prompt": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["message"],
+      "properties": {
+        "message": {
+          "$ref": "#/$defs/message"
+        }
+      }
+    },
+    "debate.turn": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["message", "round"],
+      "properties": {
+        "message": {
+          "$ref": "#/$defs/message"
+        },
+        "round": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "debate.finished": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["summary", "turns"],
+      "properties": {
+        "summary": {
+          "type": "string"
+        },
+        "turns": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    }
+  }
+}

--- a/naestro/core/summary.py
+++ b/naestro/core/summary.py
@@ -1,0 +1,59 @@
+"""Utilities for summarising recorded bus envelopes."""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from typing import Iterable, Mapping, Sequence
+
+from .bus import Envelope
+
+
+@dataclass(frozen=True, slots=True)
+class BusSummary:
+    """Aggregated view over a sequence of :class:`Envelope` objects."""
+
+    total_events: int
+    event_counts: Mapping[str, int]
+    redaction_counts: Mapping[str, int]
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "total_events": self.total_events,
+            "event_counts": dict(self.event_counts),
+            "redaction_counts": dict(self.redaction_counts),
+        }
+
+    def format(self) -> str:
+        parts: list[str] = [f"total={self.total_events}"]
+        if self.event_counts:
+            event_parts = ", ".join(
+                f"{name}:{count}" for name, count in sorted(self.event_counts.items())
+            )
+            parts.append(f"events=({event_parts})")
+        if self.redaction_counts:
+            redaction_parts = ", ".join(
+                f"{path}:{count}" for path, count in sorted(self.redaction_counts.items())
+            )
+            parts.append(f"redactions=({redaction_parts})")
+        return " | ".join(parts)
+
+
+def summarize(envelopes: Sequence[Envelope] | Iterable[Envelope]) -> BusSummary:
+    """Produce a :class:`BusSummary` from previously recorded envelopes."""
+
+    if not isinstance(envelopes, Sequence):
+        envelopes = tuple(envelopes)
+    event_counts: Counter[str] = Counter()
+    redaction_counts: Counter[str] = Counter()
+    for envelope in envelopes:
+        event_counts[envelope.event] += 1
+        redaction_counts.update(envelope.redactions)
+    return BusSummary(
+        total_events=len(envelopes),
+        event_counts=dict(event_counts),
+        redaction_counts=dict(redaction_counts),
+    )
+
+
+__all__ = ["BusSummary", "summarize"]

--- a/naestro/core/trace.py
+++ b/naestro/core/trace.py
@@ -1,0 +1,59 @@
+"""Helpers for exporting recorded envelopes to trace artifacts."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Mapping, Sequence
+
+from .bus import Envelope
+
+
+@dataclass(frozen=True, slots=True)
+class TraceEvent:
+    """Serializable representation of an :class:`Envelope`."""
+
+    sequence: int
+    event: str
+    timestamp: str
+    payload: Mapping[str, object]
+    redactions: Sequence[str]
+
+    @classmethod
+    def from_envelope(cls, envelope: Envelope) -> "TraceEvent":
+        return cls(
+            sequence=envelope.sequence,
+            event=envelope.event,
+            timestamp=envelope.timestamp.isoformat(),
+            payload=dict(envelope.payload),
+            redactions=list(envelope.redactions),
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "sequence": self.sequence,
+            "event": self.event,
+            "timestamp": self.timestamp,
+            "payload": json.loads(json.dumps(self.payload, default=str)),
+            "redactions": list(self.redactions),
+        }
+
+
+def build_trace(envelopes: Sequence[Envelope] | Iterable[Envelope]) -> list[TraceEvent]:
+    """Create :class:`TraceEvent` objects from recorded envelopes."""
+
+    if not isinstance(envelopes, Sequence):
+        envelopes = tuple(envelopes)
+    return [TraceEvent.from_envelope(envelope) for envelope in envelopes]
+
+
+def write_trace(envelopes: Sequence[Envelope] | Iterable[Envelope], target: Path) -> Path:
+    """Write envelopes to *target* as JSON trace data."""
+
+    events = [event.to_dict() for event in build_trace(envelopes)]
+    target.write_text(json.dumps(events, indent=2), encoding="utf-8")
+    return target
+
+
+__all__ = ["TraceEvent", "build_trace", "write_trace"]

--- a/tests/test_message_bus.py
+++ b/tests/test_message_bus.py
@@ -1,35 +1,65 @@
 from __future__ import annotations
 
-from typing import Callable, Dict, List
+import json
+import sys
+from pathlib import Path
+from typing import Callable, Mapping
 
-from naestro.core.bus import LoggingMiddleware, MessageBus
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:  # pragma: no cover - defensive path setup
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+jsonschema = pytest.importorskip("jsonschema")
+
+from naestro.core.bus import (
+    LoggingMiddleware,
+    MessageBus,
+    RedactionMiddleware,
+)
+from naestro.core.summary import summarize
+from naestro.core.trace import build_trace, write_trace
 
 
 def test_message_bus_middleware_sequence() -> None:
     bus = MessageBus()
-    trace: List[str] = []
+    trace: list[str] = []
 
     def middleware_one(
-        event: str, payload: object, forward: Callable[[str, object], None]
-    ) -> None:
+        event: str,
+        payload: dict[str, object],
+        forward: Callable[[str, dict[str, object]], tuple[str, dict[str, object]]],
+    ) -> tuple[str, dict[str, object]]:
         trace.append(f"mw1:{event}")
-        forward(event, payload)
+        result = forward(event, payload)
         trace.append(f"mw1:post:{event}")
+        return result
 
     def middleware_two(
-        event: str, payload: object, forward: Callable[[str, object], None]
-    ) -> None:
+        event: str,
+        payload: dict[str, object],
+        forward: Callable[[str, dict[str, object]], tuple[str, dict[str, object]]],
+    ) -> tuple[str, dict[str, object]]:
         trace.append(f"mw2:{event}")
-        forward(event, payload)
+        return forward(event, payload)
 
-    def handler(payload: object) -> None:
-        mapping = payload if isinstance(payload, dict) else {}
-        trace.append(f"handler:{mapping.get('value')}")
+    def handler(payload: Mapping[str, object]) -> None:
+        trace.append(f"handler:{payload.get('value')}")
 
     bus.use(middleware_one)
     bus.use(middleware_two)
+    bus.register_schema(
+        "test",
+        {
+            "type": "object",
+            "properties": {"value": {"type": "integer"}},
+            "required": ["value"],
+            "additionalProperties": False,
+        },
+    )
     bus.subscribe("test", handler)
-    bus.publish("test", {"value": 3})
+    envelope = bus.publish("test", {"value": 3})
 
     assert trace == [
         "mw1:test",
@@ -37,15 +67,60 @@ def test_message_bus_middleware_sequence() -> None:
         "handler:3",
         "mw1:post:test",
     ]
+    assert envelope is not None
+    assert envelope.event == "test"
+    assert dict(envelope.payload) == {"value": 3}
+    assert bus.envelopes[-1] == envelope
 
 
-def test_logging_middleware() -> None:
+def test_logging_middleware_records_payloads() -> None:
     bus = MessageBus()
-    seen: Dict[str, object] = {}
+    seen: dict[str, Mapping[str, object]] = {}
 
-    def collector(event: str, payload: object) -> None:
+    def collector(event: str, payload: Mapping[str, object]) -> None:
         seen[event] = payload
 
     bus.use(LoggingMiddleware(collector))
-    bus.publish("ping", {"payload": 1})
-    assert "ping" in seen
+    bus.publish("debate.finished", {"summary": "ok", "turns": 1})
+    assert "debate.finished" in seen
+    assert seen["debate.finished"]["summary"] == "ok"
+
+
+def test_redaction_middleware_masks_payload_and_records() -> None:
+    bus = MessageBus()
+    bus.use(RedactionMiddleware({"debate.prompt": ["message.metadata.secret"]}))
+
+    payload = {
+        "message": {
+            "role": "system",
+            "content": "hello",
+            "timestamp": "2024-01-01T00:00:00+00:00",
+            "metadata": {"secret": "token"},
+        }
+    }
+    envelope = bus.publish("debate.prompt", payload)
+    assert envelope is not None
+    redacted_message = envelope.payload["message"]
+    assert isinstance(redacted_message, Mapping)
+    assert redacted_message["metadata"]["secret"] == "***REDACTED***"
+    assert envelope.redactions == ("message.metadata.secret",)
+
+    summary = summarize(bus.envelopes)
+    assert summary.redaction_counts == {"message.metadata.secret": 1}
+
+
+def test_trace_builder_produces_serializable_output(tmp_path: Path) -> None:
+    bus = MessageBus()
+    bus.publish("debate.finished", {"summary": "done", "turns": 2})
+    trace = build_trace(bus.envelopes)
+    assert trace[0].to_dict()["event"] == "debate.finished"
+    target = tmp_path / "trace.json"
+    write_trace(bus.envelopes, target)
+    written = json.loads(target.read_text(encoding="utf-8"))
+    assert written[0]["event"] == "debate.finished"
+
+
+def test_schema_enforcement() -> None:
+    bus = MessageBus()
+    with pytest.raises(jsonschema.exceptions.ValidationError):
+        bus.publish("debate.finished", {"summary": "oops"})


### PR DESCRIPTION
## Summary
- replace the core message bus with a deterministic implementation that validates payloads against JSON Schemas, records envelopes, and supports redaction middleware
- add bundled core event schemas plus summary and trace helpers, and re-export the new utilities from `naestro.core`
- expand the message bus tests to cover envelope recording, redaction handling, trace export, and schema validation

## Testing
- `pytest tests/test_message_bus.py` *(skipped: `jsonschema` not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_b_68ce4a2e414c832a964b1ea81818f4c4