### PR TITLE
Refine governance API with typed schemas and built-in policies

### DIFF
--- a/naestro/__init__.py
+++ b/naestro/__init__.py
@@ -17,27 +17,50 @@ from .agents import (
 )
 from .core.bus import LoggingMiddleware, MessageBus
 from .core.tracing import Tracer
-from .governance.governor import Decision, Governor
-from .governance.policies import Policy
+from .governance import (
+    BudgetPolicy,
+    Decision,
+    Governor,
+    LatencySLOPolicy,
+    Policy,
+    PolicyChecker,
+    PolicyInput,
+    PolicyLike,
+    PolicyPatch,
+    PolicyResult,
+    RiskPolicy,
+    SafetyPolicy,
+    apply_patches,
+)
 from .routing.registry import ModelProfile, ModelRegistry
 from .routing.router import Router, RoutingRequest
 
 __all__ = [
+    "BudgetPolicy",
     "Decision",
     "DebateOrchestrator",
     "DebateOutcome",
     "DebateSettings",
     "DebateTranscript",
+    "Governor",
+    "LatencySLOPolicy",
     "LoggingMiddleware",
     "Message",
     "MessageBus",
     "ModelProfile",
     "ModelRegistry",
     "Policy",
+    "PolicyChecker",
+    "PolicyInput",
+    "PolicyLike",
+    "PolicyPatch",
+    "PolicyResult",
+    "RiskPolicy",
     "Role",
     "Roles",
-    "Governor",
     "Router",
     "RoutingRequest",
+    "SafetyPolicy",
     "Tracer",
+    "apply_patches",
 ]

--- a/naestro/governance/__init__.py
+++ b/naestro/governance/__init__.py
@@ -2,7 +2,31 @@
 
 from __future__ import annotations
 
-from .governor import Decision, Governor
-from .policies import Policy, PolicyResult
+from .governor import Governor, apply_patches
+from .policies import (
+    BudgetPolicy,
+    LatencySLOPolicy,
+    Policy,
+    PolicyChecker,
+    PolicyLike,
+    PolicyResult,
+    RiskPolicy,
+    SafetyPolicy,
+)
+from .schemas import Decision, PolicyInput, PolicyPatch
 
-__all__ = ["Decision", "Governor", "Policy", "PolicyResult"]
+__all__ = [
+    "BudgetPolicy",
+    "Decision",
+    "Governor",
+    "LatencySLOPolicy",
+    "Policy",
+    "PolicyChecker",
+    "PolicyInput",
+    "PolicyLike",
+    "PolicyPatch",
+    "PolicyResult",
+    "RiskPolicy",
+    "SafetyPolicy",
+    "apply_patches",
+]

--- a/naestro/governance/governor.py
+++ b/naestro/governance/governor.py
@@ -2,67 +2,173 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, List, Mapping, Sequence
+from collections.abc import Iterable, Mapping, MutableMapping, MutableSequence, Sequence
+from copy import deepcopy
+from typing import Any
 
 from naestro.core.bus import MessageBus
 
-if TYPE_CHECKING:  # pragma: no cover - typing helpers
-    from naestro.governance.policies import Policy, PolicyResult
+from .policies import PolicyLike
 
 
-@dataclass(slots=True)
-class Decision:
-    subject: str
-    score: float
-    metadata: Mapping[str, object] = field(default_factory=dict)
+class _NullBus:
+    """Fallback bus used when :mod:`jsonschema` is not available."""
 
-    def describe(self) -> str:
-        return f"Decision(subject={self.subject!r}, score={self.score})"
+    def publish(self, event: str, payload: Mapping[str, Any]) -> None:  # pragma: no cover - trivial
+        return None
+
+from .schemas import Decision, PolicyInput, PolicyPatch
+
+
+def _coerce_input(data: PolicyInput | Mapping[str, Any]) -> PolicyInput:
+    if isinstance(data, PolicyInput):
+        return data.model_copy(deep=True)
+    return PolicyInput.model_validate(data)
 
 
 class Governor:
-    """Evaluates decisions against a set of registered policies."""
+    """Evaluates inputs against a set of registered policies."""
 
     def __init__(
         self,
-        policies: Sequence["Policy"] | None = None,
+        policies: Sequence[PolicyLike] | None = None,
         *,
         bus: MessageBus | None = None,
     ) -> None:
+        self._policies: list[PolicyLike] = list(policies or [])
+        if bus is not None:
+            self._bus = bus
+        else:
+            try:
+                self._bus = MessageBus()
+            except RuntimeError:
+                self._bus = _NullBus()
 
-        self._policies: List[Policy] = list(policies or [])
-        self._bus = bus or MessageBus()
-
-    def register(self, policy: "Policy") -> None:
+    def register(self, policy: PolicyLike) -> None:
         self._policies.append(policy)
 
     def clear(self) -> None:
         self._policies.clear()
 
-    def evaluate(self, decision: Decision) -> List["PolicyResult"]:
+    def evaluate(
+        self, data: PolicyInput | Mapping[str, Any]
+    ) -> list[Decision]:
+        policy_input = _coerce_input(data)
+        return [policy.evaluate(policy_input) for policy in self._policies]
 
-        results: List[PolicyResult] = []
+    def enforce(
+        self,
+        data: PolicyInput | Mapping[str, Any],
+        *,
+        apply_policy_patches: bool = False,
+        return_input: bool = False,
+    ) -> tuple[bool, list[Decision]] | tuple[bool, list[Decision], PolicyInput]:
+        policy_input = _coerce_input(data)
+        plan = deepcopy(policy_input.plan)
+        results: list[Decision] = []
         for policy in self._policies:
-            results.append(policy.evaluate(decision))
-        return results
-
-    def enforce(self, decision: Decision) -> tuple[bool, List["PolicyResult"]]:
-        results = self.evaluate(decision)
+            decision = policy.evaluate(policy_input)
+            results.append(decision)
+            if apply_policy_patches and decision.patches:
+                plan = apply_patches(plan, decision.patches)
+                policy_input.plan = plan
         allowed = all(result.passed for result in results)
         payload = {
-            "decision": decision.describe(),
-            "results": [
-                {
-                    "policy": result.name,
-                    "passed": result.passed,
-                    "reason": result.reason,
-                }
-                for result in results
-            ],
+            "input": policy_input.model_dump(),
+            "results": [result.model_dump() for result in results],
+            "approved": allowed,
         }
         self._bus.publish("governor.evaluated", payload)
+        if return_input:
+            return allowed, results, policy_input
         return allowed, results
 
 
-__all__ = ["Decision", "Governor"]
+def _ensure_container(
+    container: Any,
+    key: str | int,
+    *,
+    create: bool,
+) -> Any:
+    if isinstance(key, int):
+        if not isinstance(container, MutableSequence):
+            raise TypeError("Expected a sequence for integer path segments")
+        if key >= len(container):
+            if not create:
+                raise IndexError(f"Index {key} out of range for patch path")
+            while len(container) <= key:
+                container.append({})
+        return container[key]
+    if not isinstance(container, MutableMapping):
+        raise TypeError("Expected a mapping for string path segments")
+    if key not in container:
+        if not create:
+            raise KeyError(f"Missing key {key!r} in patch path")
+        container[key] = {}
+    return container[key]
+
+
+def _assign(container: Any, key: str | int, value: Any) -> None:
+    if isinstance(key, int):
+        if not isinstance(container, MutableSequence):
+            raise TypeError("Expected a sequence for integer assignment")
+        if key == len(container):
+            container.append(value)
+            return
+        if key >= len(container):
+            raise IndexError(f"Index {key} out of range for assignment")
+        container[key] = value
+        return
+    if not isinstance(container, MutableMapping):
+        raise TypeError("Expected a mapping for string assignment")
+    container[key] = value
+
+
+def _remove(container: Any, key: str | int) -> None:
+    if isinstance(key, int):
+        if not isinstance(container, MutableSequence):
+            raise TypeError("Expected a sequence for integer removal")
+        if not (-len(container) <= key < len(container)):
+            raise IndexError(f"Index {key} out of range for removal")
+        del container[key]
+        return
+    if not isinstance(container, MutableMapping):
+        raise TypeError("Expected a mapping for string removal")
+    container.pop(key, None)
+
+
+def apply_patches(plan: Mapping[str, Any], patches: Iterable[PolicyPatch]) -> dict[str, Any]:
+    """Apply a collection of declarative patches to the supplied plan."""
+
+    result: Any = deepcopy(plan)
+    for patch in patches:
+        path = list(patch.get("path", ()))
+        if not path:
+            raise ValueError("Patch operations require a non-empty path")
+        op = patch.get("op", "set")
+        value = deepcopy(patch.get("value")) if "value" in patch else None
+        current = result
+        for segment in path[:-1]:
+            current = _ensure_container(current, segment, create=op in {"set", "merge"})
+        final_segment = path[-1]
+        if op == "set":
+            _assign(current, final_segment, value)
+        elif op == "remove":
+            _remove(current, final_segment)
+        elif op == "merge":
+            target = _ensure_container(current, final_segment, create=True)
+            if not isinstance(target, MutableMapping):
+                raise TypeError("Merge operations require a mapping target")
+            if value is None:
+                continue
+            if not isinstance(value, Mapping):
+                raise TypeError("Merge values must be mappings")
+            target.update(value)
+        else:  # pragma: no cover - defensive programming
+            raise ValueError(f"Unsupported patch operation: {op!r}")
+    if isinstance(result, MutableMapping):
+        return dict(result)
+    return result
+
+
+__all__ = ["Decision", "Governor", "PolicyInput", "PolicyPatch", "apply_patches"]

--- a/naestro/governance/policies.py
+++ b/naestro/governance/policies.py
@@ -3,30 +3,223 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Callable
+from typing import Callable, Protocol
 
-if TYPE_CHECKING:  # pragma: no cover - import for typing only
-    from naestro.governance.governor import Decision
+from .schemas import Decision, PolicyInput
 
 
-@dataclass(slots=True)
-class PolicyResult:
+PolicyResult = Decision
+"""Alias maintained for backwards compatibility with earlier releases."""
+
+
+PolicyChecker = Callable[[PolicyInput], Decision]
+"""Callable signature used by :class:`Policy` wrappers."""
+
+
+class PolicyLike(Protocol):
+    """Structural protocol implemented by policy objects."""
+
     name: str
-    passed: bool
-    reason: str
+    description: str
 
-
-PolicyChecker = Callable[["Decision"], PolicyResult]
+    def evaluate(self, policy_input: PolicyInput) -> Decision:  # pragma: no cover - protocol method
+        """Evaluate the provided input and return a policy decision."""
 
 
 @dataclass(slots=True)
 class Policy:
+    """Wraps a simple callable into a policy instance."""
+
     name: str
     description: str
     checker: PolicyChecker
 
-    def evaluate(self, decision: "Decision") -> PolicyResult:
-        return self.checker(decision)
+    def evaluate(self, policy_input: PolicyInput) -> Decision:
+        return self.checker(policy_input)
 
 
-__all__ = ["Policy", "PolicyChecker", "PolicyResult"]
+@dataclass(slots=True)
+class BudgetPolicy:
+    """Ensure usage stays within a configured budget."""
+
+    name: str = "budget"
+    description: str = "Validate that expected spend does not exceed the available budget."
+
+    def evaluate(self, policy_input: PolicyInput) -> Decision:
+        budget = policy_input.budget
+        if budget is None:
+            return Decision(
+                name=self.name,
+                passed=True,
+                reason="No budget configuration provided",
+            )
+        limit = budget.limit
+        usage = budget.usage
+        currency = budget.currency
+        metadata = {
+            "limit": limit,
+            "usage": usage,
+            "currency": currency,
+        }
+        if limit is None or usage is None:
+            return Decision(
+                name=self.name,
+                passed=True,
+                reason="Budget data incomplete",
+                metadata=metadata,
+            )
+        usage_value = float(usage)
+        limit_value = float(limit)
+        metadata |= {"usage": usage_value, "limit": limit_value}
+        if usage_value <= limit_value:
+            reason = f"{usage_value:.2f} {currency} within {limit_value:.2f} {currency} budget"
+            return Decision(name=self.name, passed=True, reason=reason, metadata=metadata)
+        excess = usage_value - limit_value
+        metadata["excess"] = excess
+        reason = (
+            f"{usage_value:.2f} {currency} exceeds budget {limit_value:.2f} {currency} "
+            f"by {excess:.2f} {currency}"
+        )
+        return Decision(
+            name=self.name,
+            passed=False,
+            reason=reason,
+            severity="critical",
+            metadata=metadata,
+        )
+
+
+@dataclass(slots=True)
+class SafetyPolicy:
+    """Check flagged categories against the configured block list."""
+
+    name: str = "safety"
+    description: str = "Ensure content moderation checks do not report blocked categories."
+
+    def evaluate(self, policy_input: PolicyInput) -> Decision:
+        safety = policy_input.safety
+        if safety is None:
+            return Decision(name=self.name, passed=True, reason="No safety signals provided")
+        blocked = set(safety.blocked_categories)
+        flagged = set(safety.flagged_categories)
+        violations = sorted(blocked & flagged)
+        metadata = {
+            "blocked_categories": sorted(blocked),
+            "flagged_categories": sorted(flagged),
+            "annotations": dict(safety.annotations),
+        }
+        if not violations:
+            return Decision(
+                name=self.name,
+                passed=True,
+                reason="No blocked categories flagged",
+                metadata=metadata,
+            )
+        metadata["violations"] = violations
+        reason = "Flagged blocked categories: " + ", ".join(violations)
+        return Decision(
+            name=self.name,
+            passed=False,
+            reason=reason,
+            severity="critical",
+            metadata=metadata,
+        )
+
+
+@dataclass(slots=True)
+class RiskPolicy:
+    """Validate that the risk score is below an acceptable threshold."""
+
+    name: str = "risk"
+    description: str = "Require the risk score to remain under the configured threshold."
+    max_score: float | None = None
+
+    def evaluate(self, policy_input: PolicyInput) -> Decision:
+        risk = policy_input.risk
+        score = float(risk.score) if risk and risk.score is not None else None
+        threshold = (
+            float(risk.threshold)
+            if risk and risk.threshold is not None
+            else (float(self.max_score) if self.max_score is not None else None)
+        )
+        metadata = {
+            "score": score,
+            "threshold": threshold,
+            "label": risk.label if risk else None,
+        }
+        if score is None or threshold is None:
+            return Decision(
+                name=self.name,
+                passed=True,
+                reason="No risk constraints provided",
+                metadata=metadata,
+            )
+        passed = score <= threshold
+        if passed:
+            reason = f"risk score {score:.2f} within threshold {threshold:.2f}"
+        else:
+            reason = f"risk score {score:.2f} exceeds threshold {threshold:.2f}"
+        severity = "info" if passed else "warning"
+        return Decision(
+            name=self.name,
+            passed=passed,
+            reason=reason,
+            severity=severity,
+            metadata=metadata,
+        )
+
+
+@dataclass(slots=True)
+class LatencySLOPolicy:
+    """Ensure latency measurements remain within an SLO."""
+
+    name: str = "latency_slo"
+    description: str = "Validate that observed latency does not exceed the SLO."
+    slo_ms: float | None = None
+
+    def evaluate(self, policy_input: PolicyInput) -> Decision:
+        latency = policy_input.latency
+        observed = float(latency.value_ms) if latency and latency.value_ms is not None else None
+        slo = (
+            float(latency.slo_ms)
+            if latency and latency.slo_ms is not None
+            else (float(self.slo_ms) if self.slo_ms is not None else None)
+        )
+        metadata = {
+            "observed_ms": observed,
+            "slo_ms": slo,
+            "window": latency.window if latency else None,
+        }
+        if observed is None or slo is None:
+            return Decision(
+                name=self.name,
+                passed=True,
+                reason="Latency data unavailable",
+                metadata=metadata,
+            )
+        passed = observed <= slo
+        if passed:
+            reason = f"latency {observed:.2f}ms within SLO {slo:.2f}ms"
+        else:
+            reason = f"latency {observed:.2f}ms exceeds SLO {slo:.2f}ms"
+        severity = "info" if passed else "warning"
+        return Decision(
+            name=self.name,
+            passed=passed,
+            reason=reason,
+            severity=severity,
+            metadata=metadata,
+        )
+
+
+__all__ = [
+    "BudgetPolicy",
+    "Decision",
+    "LatencySLOPolicy",
+    "Policy",
+    "PolicyChecker",
+    "PolicyLike",
+    "PolicyResult",
+    "RiskPolicy",
+    "SafetyPolicy",
+]

--- a/naestro/governance/schemas.py
+++ b/naestro/governance/schemas.py
@@ -1,0 +1,124 @@
+"""Typed schemas used by the governance subsystem."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any, Literal, TypedDict
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class BudgetContext(BaseModel):
+    """Budget information associated with a policy evaluation."""
+
+    limit: float | None = Field(
+        default=None,
+        description="Maximum permitted spend expressed in the selected currency.",
+    )
+    usage: float | None = Field(
+        default=None,
+        description="Expected spend for the current request or workflow stage.",
+    )
+    currency: str = Field(
+        default="usd",
+        description="Currency code for the budget figures (ISO 4217 preferred).",
+    )
+
+
+class SafetyContext(BaseModel):
+    """Signals emitted by safety classifiers or heuristic filters."""
+
+    blocked_categories: set[str] = Field(
+        default_factory=set,
+        description="Categories that are disallowed for the current workflow.",
+    )
+    flagged_categories: set[str] = Field(
+        default_factory=set,
+        description="Categories flagged by upstream moderation systems.",
+    )
+    annotations: Mapping[str, Any] = Field(
+        default_factory=dict,
+        description="Raw annotations provided by the moderation system.",
+    )
+
+
+class RiskContext(BaseModel):
+    """Structured risk metrics produced by a scoring component."""
+
+    score: float | None = Field(
+        default=None,
+        description="Calculated risk score for the request.",
+    )
+    threshold: float | None = Field(
+        default=None,
+        description="Maximum acceptable risk score for the request.",
+    )
+    label: str | None = Field(
+        default=None,
+        description="Optional textual descriptor for the risk score.",
+    )
+
+
+class LatencyContext(BaseModel):
+    """Latency measurements gathered from observability systems."""
+
+    value_ms: float | None = Field(
+        default=None,
+        description="Observed or projected latency in milliseconds.",
+    )
+    slo_ms: float | None = Field(
+        default=None,
+        description="Latency service level objective in milliseconds.",
+    )
+    window: str | None = Field(
+        default=None,
+        description="Window or quantile associated with the latency measurement.",
+    )
+
+
+class PolicyPatch(TypedDict, total=False):
+    """Declarative patch operation produced by a policy decision."""
+
+    op: Literal["set", "remove", "merge"]
+    path: Sequence[str | int]
+    value: Any
+
+
+class PolicyInput(BaseModel):
+    """Input payload evaluated by governance policies."""
+
+    model_config = ConfigDict(extra="allow")
+
+    subject: str
+    score: float | None = Field(default=None)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    plan: dict[str, Any] = Field(default_factory=dict)
+    budget: BudgetContext | None = None
+    safety: SafetyContext | None = None
+    risk: RiskContext | None = None
+    latency: LatencyContext | None = None
+
+
+class Decision(BaseModel):
+    """Outcome emitted by a policy evaluation."""
+
+    model_config = ConfigDict(extra="allow")
+
+    name: str
+    passed: bool
+    reason: str
+    severity: Literal["info", "warning", "critical"] = "info"
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    score: float | None = Field(default=None)
+    patches: tuple[PolicyPatch, ...] = Field(default_factory=tuple)
+
+
+__all__ = [
+    "BudgetContext",
+    "Decision",
+    "LatencyContext",
+    "PolicyInput",
+    "PolicyPatch",
+    "RiskContext",
+    "SafetyContext",
+]

--- a/tests/test_governor.py
+++ b/tests/test_governor.py
@@ -1,26 +1,27 @@
 from __future__ import annotations
 
-from naestro.governance import Decision, Governor, Policy, PolicyResult
+from naestro.governance import Decision, Governor, Policy, PolicyInput
 
 
 def test_governor_enforces_policies() -> None:
     governor = Governor()
 
-    def positive_return(decision: Decision) -> PolicyResult:
-        passed = decision.score > 0
+    def positive_return(payload: PolicyInput) -> Decision:
+        score = payload.score or 0.0
+        passed = score > 0
         reason = "positive" if passed else "negative"
-        return PolicyResult(name="positive_return", passed=passed, reason=reason)
+        return Decision(name="positive_return", passed=passed, reason=reason)
 
-    def drawdown_cap(decision: Decision) -> PolicyResult:
-        drawdown = float(decision.metadata.get("max_drawdown", 0.0))
+    def drawdown_cap(payload: PolicyInput) -> Decision:
+        drawdown = float(payload.metadata.get("max_drawdown", 0.0))
         passed = drawdown <= 1.5
         reason = "ok" if passed else "too high"
-        return PolicyResult(name="drawdown_cap", passed=passed, reason=reason)
+        return Decision(name="drawdown_cap", passed=passed, reason=reason)
 
     governor.register(Policy("return", "Requires positive return", positive_return))
     governor.register(Policy("drawdown", "Caps drawdown", drawdown_cap))
 
-    decision = Decision(subject="test", score=0.1, metadata={"max_drawdown": 2.0})
-    allowed, results = governor.enforce(decision)
+    policy_input = PolicyInput(subject="test", score=0.1, metadata={"max_drawdown": 2.0})
+    allowed, results = governor.enforce(policy_input)
     assert not allowed
     assert any(not result.passed for result in results)


### PR DESCRIPTION
## Summary
- add `PolicyInput`/`Decision` schemas and patch metadata to the governance module
- implement built-in budget, safety, risk, and latency policies plus patch application helpers
- update exports, examples, and tests to consume the new governance API

## Testing
- PYTHONPATH=. pytest tests/test_governor.py

------
https://chatgpt.com/codex/tasks/task_b_68ce4c9b995c832a8857147ffe1e1f91