### PR TITLE
Update examples and CLI for new Naestro APIs

### DIFF
--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -1,0 +1,3 @@
+"""Utility scripts showcasing the Naestro runtime APIs."""
+
+__all__ = []

--- a/examples/cli.py
+++ b/examples/cli.py
@@ -12,12 +12,12 @@ from naestro import cli
 
 
 def main() -> None:
-    print("== List roles ==")
-    cli.main(["list-roles"])
-    print("\n== Run debate ==")
+    print("== Run debate demo ==")
     cli.main(["run-debate", "--prompt", "Is the setup favorable?", "--rounds", "2"])
-    print("\n== Run pipeline ==")
-    cli.main(["run-pipeline"])
+    print("\n== Run trading demo ==")
+    cli.main(["run-trading"])
+    print("\n== Run governed trading demo ==")
+    cli.main(["run-governed"])
 
 
 if __name__ == "__main__":

--- a/examples/routing_profiles.py
+++ b/examples/routing_profiles.py
@@ -1,4 +1,4 @@
-"""Showcase the routing registry selecting an appropriate model."""
+"""Showcase selecting an appropriate model using the router APIs."""
 
 from __future__ import annotations
 
@@ -8,10 +8,12 @@ from pathlib import Path
 if __package__ in {None, ""}:
     sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from naestro.routing import BaseTaskSpec, ModelInfo, ModelRouter
+from naestro import BaseTaskSpec, ModelInfo, ModelRouter
 
 
 def build_router() -> ModelRouter:
+    """Seed the router with a few sample models."""
+
     models = [
         ModelInfo(
             name="foundational-small",


### PR DESCRIPTION
## Summary
- package the examples module and refresh the debate, governed pipeline, and routing demos to import the consolidated Naestro APIs
- update the scripted CLI demo to exercise the debate, trading, and governed trading flows
- extend `naestro.cli` with `run-trading` and `run-governed` subcommands that delegate to the trading demo helpers

## Testing
- python -m compileall examples naestro/cli.py

------
https://chatgpt.com/codex/tasks/task_b_68ce554e47fc832a929a233252bacfaa