### PR TITLE
Add YAML configs for trading demo and routing examples

### DIFF
--- a/configs/policies_basic.yaml
+++ b/configs/policies_basic.yaml
@@ -1,0 +1,3 @@
+policies:
+  max_drawdown: 2.0
+  min_return: 0.5

--- a/configs/router_profiles.yaml
+++ b/configs/router_profiles.yaml
@@ -1,0 +1,26 @@
+models:
+  - name: foundational-small
+    provider: naestro
+    capabilities:
+      - chat
+      - analysis
+    quality: 0.7
+    latency: 0.2
+    cost: 0.1
+  - name: foundational-pro
+    provider: naestro
+    capabilities:
+      - chat
+      - analysis
+      - math
+    quality: 0.9
+    latency: 0.4
+    cost: 0.3
+  - name: specialist-coder
+    provider: partner
+    capabilities:
+      - code
+      - analysis
+    quality: 0.85
+    latency: 0.3
+    cost: 0.25

--- a/configs/trading_demo.yaml
+++ b/configs/trading_demo.yaml
@@ -1,0 +1,6 @@
+signal_window: 3
+max_exposure: 1
+min_confidence: 0.2
+risk_policies:
+  max_drawdown: 2.0
+  min_return: 0.5

--- a/examples/routing_profiles.py
+++ b/examples/routing_profiles.py
@@ -5,42 +5,40 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import yaml
+
 if __package__ in {None, ""}:
     sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from naestro import BaseTaskSpec, ModelInfo, ModelRouter
 
 
+CONFIG_PATH = Path(__file__).resolve().parents[1] / "configs" / "router_profiles.yaml"
+
+
+def _load_model_profiles() -> list[ModelInfo]:
+    """Load model definitions from the router profiles configuration."""
+
+    data = yaml.safe_load(CONFIG_PATH.read_text()) or {}
+    models = []
+    for entry in data.get("models", []):
+        models.append(
+            ModelInfo(
+                name=entry["name"],
+                provider=entry["provider"],
+                capabilities=frozenset(entry.get("capabilities", [])),
+                quality=float(entry["quality"]),
+                latency=float(entry["latency"]),
+                cost=float(entry["cost"]),
+            )
+        )
+    return models
+
+
 def build_router() -> ModelRouter:
     """Seed the router with a few sample models."""
 
-    models = [
-        ModelInfo(
-            name="foundational-small",
-            provider="naestro",
-            capabilities=frozenset({"chat", "analysis"}),
-            quality=0.7,
-            latency=0.2,
-            cost=0.1,
-        ),
-        ModelInfo(
-            name="foundational-pro",
-            provider="naestro",
-            capabilities=frozenset({"chat", "analysis", "math"}),
-            quality=0.9,
-            latency=0.4,
-            cost=0.3,
-        ),
-        ModelInfo(
-            name="specialist-coder",
-            provider="partner",
-            capabilities=frozenset({"code", "analysis"}),
-            quality=0.85,
-            latency=0.3,
-            cost=0.25,
-        ),
-    ]
-    return ModelRouter(models)
+    return ModelRouter(_load_model_profiles())
 
 
 def main() -> None:

--- a/tests/configs/test_policies_basic_config.py
+++ b/tests/configs/test_policies_basic_config.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+CONFIG_PATH = Path("configs/policies_basic.yaml")
+
+
+EXPECTED_POLICIES = {
+    "max_drawdown": 2.0,
+    "min_return": 0.5,
+}
+
+
+def test_policies_basic_config_matches_prompt() -> None:
+    data = yaml.safe_load(CONFIG_PATH.read_text())
+    assert data == {"policies": EXPECTED_POLICIES}

--- a/tests/configs/test_router_profiles_config.py
+++ b/tests/configs/test_router_profiles_config.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+CONFIG_PATH = Path("configs/router_profiles.yaml")
+
+
+EXPECTED_MODELS = [
+    {
+        "name": "foundational-small",
+        "provider": "naestro",
+        "capabilities": ["chat", "analysis"],
+        "quality": 0.7,
+        "latency": 0.2,
+        "cost": 0.1,
+    },
+    {
+        "name": "foundational-pro",
+        "provider": "naestro",
+        "capabilities": ["chat", "analysis", "math"],
+        "quality": 0.9,
+        "latency": 0.4,
+        "cost": 0.3,
+    },
+    {
+        "name": "specialist-coder",
+        "provider": "partner",
+        "capabilities": ["code", "analysis"],
+        "quality": 0.85,
+        "latency": 0.3,
+        "cost": 0.25,
+    },
+]
+
+
+def test_router_profiles_config_matches_prompt() -> None:
+    data = yaml.safe_load(CONFIG_PATH.read_text())
+    assert data == {"models": EXPECTED_MODELS}

--- a/tests/configs/test_trading_demo_config.py
+++ b/tests/configs/test_trading_demo_config.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+CONFIG_PATH = Path("configs/trading_demo.yaml")
+
+
+def test_trading_demo_config_matches_prompt() -> None:
+    data = yaml.safe_load(CONFIG_PATH.read_text())
+    assert data == {
+        "signal_window": 3,
+        "max_exposure": 1,
+        "min_confidence": 0.2,
+        "risk_policies": {
+            "max_drawdown": 2.0,
+            "min_return": 0.5,
+        },
+    }


### PR DESCRIPTION
## Summary
- add trading demo, router profiles, and policies YAML configuration files
- update the routing and governed pipeline examples to load settings from the new configuration files
- add regression tests that validate the configuration contents against the documented prompt values

## Testing
- pytest tests/configs -q

------
https://chatgpt.com/codex/tasks/task_b_68ce57173508832a9caecd726cf7de10