### PR TITLE
Update debate, governance, routing, and trading tests for new APIs

### DIFF
--- a/tests/packs/trading/test_backtest_smoke.py
+++ b/tests/packs/trading/test_backtest_smoke.py
@@ -1,19 +1,29 @@
 from __future__ import annotations
 
+import sys
+from pathlib import Path
+
 import pytest
+
+if __package__ in {None, ""}:
+    sys.path.append(str(Path(__file__).resolve().parents[3]))
 
 from packs.trading import run_backtest
 from packs.trading.agents import TradeDecision
 
 
-def test_backtest_runs() -> None:
-    prices = [100.0, 101.0, 102.0, 101.0]
+def test_backtest_runs_and_computes_metrics() -> None:
+    prices = [100.0, 101.0, 100.0, 103.0]
     trades = [
         TradeDecision(index=0, position=1, price=100.0, note="enter"),
-        TradeDecision(index=1, position=0, price=101.0, note="flat"),
-        TradeDecision(index=2, position=1, price=102.0, note="enter"),
+        TradeDecision(index=1, position=1, price=101.0, note="hold"),
+        TradeDecision(index=2, position=1, price=100.0, note="reenter"),
     ]
     result = run_backtest(prices, trades)
-    assert result.metrics["cumulative_return"] == pytest.approx(0.0)
-    assert result.metrics["win_rate"] == pytest.approx(1 / 3)
+
+    assert [round(value, 6) for value in result.returns] == [1.0, -1.0, 3.0]
+    assert result.equity_curve == [1.0, 0.0, 3.0]
+    assert result.metrics["cumulative_return"] == pytest.approx(3.0)
+    assert result.metrics["win_rate"] == pytest.approx(2 / 3)
     assert result.metrics["max_drawdown"] == pytest.approx(1.0)
+    assert result.metrics["profit_factor"] == pytest.approx(4.0)

--- a/tests/test_debate_basic.py
+++ b/tests/test_debate_basic.py
@@ -1,36 +1,70 @@
 from __future__ import annotations
 
-from typing import List, Sequence
+import sys
+from pathlib import Path
+from typing import Sequence
 
-from naestro.agents import DebateOrchestrator, DebateSettings, Message, Role, Roles
+if __package__ in {None, ""}:
+    sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import pytest
+
+pytest.importorskip("jsonschema")
+
+from naestro.agents.debate import DebateOrchestrator, DebateOutcome, DebateSettings
+from naestro.agents.roles import Role, Roles
+from naestro.agents.schemas import Message
 from naestro.core.bus import MessageBus
 
 
-def test_orchestrator_runs_rounds() -> None:
+def test_orchestrator_runs_rounds_and_emits_events() -> None:
     def analyst(history: Sequence[Message]) -> str:
-        return f"analysis {len(history)}"
+        return f"analysis-{len(history)}"
 
     def critic(history: Sequence[Message]) -> str:
-        return "approve" if len(history) > 0 else "needs more"
+        if history and history[-1].role == "analyst":
+            return "approve"
+        return "continue"
 
     roles = Roles()
     roles.register(Role("analyst", "Provides initial view", analyst))
     roles.register(Role("critic", "Challenges proposals", critic))
+
     bus = MessageBus()
-    rounds: List[int] = []
+    rounds: list[int] = []
+    bus.subscribe("debate.turn", lambda payload: rounds.append(int(payload["round"])))
 
-    def record(payload: object) -> None:
-        mapping = payload if isinstance(payload, dict) else {}
-        rounds.append(int(mapping["round"]))
-
-    bus.subscribe("debate.turn", record)
     orchestrator = DebateOrchestrator(roles, bus=bus)
-    outcome = orchestrator.run(
-        ["analyst", "critic"],
-        "Is the trade compelling?",
-        settings=DebateSettings(rounds=2),
-    )
-    assert len(outcome.transcript.messages) == 5
-    assert outcome.transcript.messages[0].role == "system"
+    settings = DebateSettings(rounds=2, initial_offset=5, tags={"scenario": "trade"})
+    outcome = orchestrator.run(["analyst", "critic"], "Evaluate the setup", settings=settings)
+
+    assert isinstance(outcome, DebateOutcome)
+    transcript = outcome.transcript
+    assert transcript.tags == {"scenario": "trade"}
+    assert [message.metadata["round"] for message in transcript.messages[1:]] == [0, 0, 1, 1]
+    assert transcript.messages[0].metadata == {"round": -1, "order": -1}
+    assert transcript.messages[0].timestamp.isoformat() == "2024-01-01T00:00:05+00:00"
+    assert transcript.messages[-1].content == "approve"
+    assert outcome.approved is True
+    assert outcome.rationale == "Debate[analyst, critic]: critic:approve, analyst:analysis-3, critic:approve"
+
+    events = [envelope.event for envelope in bus.envelopes]
+    assert events == [
+        "debate.started",
+        "debate.prompt",
+        "debate.turn",
+        "debate.turn",
+        "debate.turn",
+        "debate.turn",
+        "debate.finished",
+    ]
+
+    started_payload = bus.envelopes[0].payload
+    assert started_payload["participants"] == ["analyst", "critic"]
+    assert started_payload["prompt"] == "Evaluate the setup"
+    finished_payload = bus.envelopes[-1].payload
+    assert finished_payload["turns"] == len(transcript.messages)
     assert rounds == [0, 0, 1, 1]
-    assert outcome.transcript.messages[-1].content == "approve"
+
+    known_events = set(bus.known_events)
+    assert {"debate.started", "debate.turn", "debate.prompt", "debate.finished"} <= known_events

--- a/tests/test_governor.py
+++ b/tests/test_governor.py
@@ -1,10 +1,44 @@
 from __future__ import annotations
 
-from naestro.governance import Decision, Governor, Policy, PolicyInput
+import sys
+from pathlib import Path
+from typing import Mapping
+
+if __package__ in {None, ""}:
+    sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import pytest
+
+pytest.importorskip("jsonschema")
+
+from naestro.core.bus import MessageBus
+from naestro.governance.governor import Governor, apply_patches
+from naestro.governance.policies import Policy
+from naestro.governance.schemas import Decision, PolicyInput
 
 
-def test_governor_enforces_policies() -> None:
-    governor = Governor()
+def _governor_schema() -> Mapping[str, object]:
+    return {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "events": {
+            "governor.evaluated": {
+                "type": "object",
+                "additionalProperties": False,
+                "required": ["input", "results", "approved"],
+                "properties": {
+                    "input": {"type": "object"},
+                    "results": {"type": "array"},
+                    "approved": {"type": "boolean"},
+                },
+            }
+        },
+    }
+
+
+def test_governor_enforces_policies_and_publishes_results() -> None:
+    bus = MessageBus(schema=_governor_schema())
+    published: list[Mapping[str, object]] = []
+    bus.subscribe("governor.evaluated", lambda payload: published.append(payload))
 
     def positive_return(payload: PolicyInput) -> Decision:
         score = payload.score or 0.0
@@ -15,13 +49,51 @@ def test_governor_enforces_policies() -> None:
     def drawdown_cap(payload: PolicyInput) -> Decision:
         drawdown = float(payload.metadata.get("max_drawdown", 0.0))
         passed = drawdown <= 1.5
-        reason = "ok" if passed else "too high"
-        return Decision(name="drawdown_cap", passed=passed, reason=reason)
+        patches: tuple[dict[str, object], ...] = ()
+        if not passed:
+            patches = ({"op": "set", "path": ("status",), "value": "review"},)
+        decision = Decision(
+            name="drawdown_cap",
+            passed=passed,
+            reason="ok" if passed else "too high",
+            patches=patches,
+        )
+        return decision
 
-    governor.register(Policy("return", "Requires positive return", positive_return))
-    governor.register(Policy("drawdown", "Caps drawdown", drawdown_cap))
+    policies = [
+        Policy("return", "Requires positive return", positive_return),
+        Policy("drawdown", "Caps drawdown", drawdown_cap),
+    ]
+    governor = Governor(policies, bus=bus)
 
-    policy_input = PolicyInput(subject="test", score=0.1, metadata={"max_drawdown": 2.0})
-    allowed, results = governor.enforce(policy_input)
+    policy_input = PolicyInput(
+        subject="test",
+        score=-0.1,
+        metadata={"max_drawdown": 2.0},
+        plan={"status": "proposed"},
+    )
+    allowed, results, updated_input = governor.enforce(
+        policy_input, apply_policy_patches=True, return_input=True
+    )
+
     assert not allowed
-    assert any(not result.passed for result in results)
+    assert [result.passed for result in results] == [False, False]
+    assert updated_input.plan["status"] == "review"
+    assert bus.envelopes[0].event == "governor.evaluated"
+    assert published and published[0]["approved"] is False
+    assert len(published[0]["results"]) == 2
+
+
+def test_apply_patches_supports_merge_and_remove() -> None:
+    plan = {"status": "pending", "steps": [{"name": "a"}, {"name": "b"}]}
+    patches = (
+        {"op": "set", "path": ("steps", 0, "name"), "value": "approved"},
+        {"op": "remove", "path": ("steps", 1)},
+        {"op": "merge", "path": ("metadata",), "value": {"owner": "alice"}},
+    )
+
+    updated = apply_patches(plan, patches)
+    assert updated["steps"][0]["name"] == "approved"
+    assert len(updated["steps"]) == 1
+    assert updated["metadata"]["owner"] == "alice"
+    assert "metadata" not in plan

--- a/tests/test_router_selection.py
+++ b/tests/test_router_selection.py
@@ -3,35 +3,74 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import pytest
+
 if __package__ in {None, ""}:
     sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from naestro.routing import BaseTaskSpec, ModelInfo, ModelRouter
+from naestro.routing.model_registry import ModelInfo
+from naestro.routing.router import ModelRouter
 
 
-def test_router_selects_best_model() -> None:
+def test_router_ranks_models_and_applies_constraints() -> None:
     models = [
         ModelInfo(
-            name="a",
-            provider="test",
-            capabilities=frozenset({"chat"}),
-            quality=0.6,
-            latency=0.2,
-            cost=0.1,
-        ),
-        ModelInfo(
-            name="b",
-            provider="test",
+            name="balanced",
+            provider="demo",
             capabilities=frozenset({"chat", "analysis"}),
-            quality=0.9,
+            quality=0.82,
             latency=0.3,
             cost=0.2,
         ),
+        ModelInfo(
+            name="high_quality",
+            provider="demo",
+            capabilities=frozenset({"analysis"}),
+            quality=0.9,
+            latency=0.35,
+            cost=0.25,
+        ),
+        ModelInfo(
+            name="fast",
+            provider="demo",
+            capabilities=frozenset({"chat", "analysis"}),
+            quality=0.75,
+            latency=0.1,
+            cost=0.18,
+        ),
     ]
     router = ModelRouter(models)
-    request: BaseTaskSpec = {
+
+    base_spec = {
         "task": "analysis",
         "required_capabilities": {"analysis"},
     }
-    selected = router.select_model(request)
-    assert selected.name == "b"
+    ranked = router.rank_models(base_spec)
+    assert [model.name for model in ranked] == [
+        "high_quality",
+        "fast",
+        "balanced",
+    ]
+
+    latency_weighted = {
+        "task": "analysis",
+        "required_capabilities": {"analysis"},
+        "weights": {"quality": 0.4, "latency": 0.5, "cost": 0.1},
+    }
+    latency_ranked = router.rank_models(latency_weighted)
+    assert latency_ranked[0].name == "fast"
+
+    selected = router.select_model(
+        {
+            "task": "analysis",
+            "required_capabilities": {"analysis"},
+            "exclude": {"high_quality"},
+            "max_cost": 0.2,
+            "max_latency": 0.3,
+            "min_quality": 0.75,
+        }
+    )
+    assert selected.name == "fast"
+
+    with pytest.raises(ValueError):
+        router.select_model({"task": "vision", "required_capabilities": {"vision"}})


### PR DESCRIPTION
## Summary
- refresh the debate orchestration test to exercise the new DebateOrchestrator API, transcript metadata, and bus events
- expand the roles registry, message bus, governor, and router unit tests to cover the updated module interfaces and behaviours
- update the trading pack smoke tests to validate backtest metrics and debate gate prompting while skipping when jsonschema is unavailable

## Testing
- pytest tests/test_debate_basic.py tests/test_roles_registry.py tests/test_message_bus.py tests/test_governor.py tests/test_router_selection.py tests/packs/trading/test_backtest_smoke.py tests/packs/trading/test_pipeline_debate_gate.py

------
https://chatgpt.com/codex/tasks/task_b_68ce636bcf40832a8f4e3d096ad890f3