### PR TITLE
Refine top-level Naestro exports

### DIFF
--- a/naestro/__init__.py
+++ b/naestro/__init__.py
@@ -1,49 +1,44 @@
-"""Core public API surface for the lightweight Naestro runtime package.
-
-This module exposes the most frequently used primitives so that example code and
-third party extensions can import them directly from :mod:`naestro`.
-"""
+"""Public re-exports for the most frequently used Naestro primitives."""
 
 from __future__ import annotations
 
-from .agents import (
+from .agents.debate import (  # noqa: F401
     DebateOrchestrator,
     DebateOutcome,
     DebateSettings,
-    DebateTranscript,
-    Message,
-    Role,
-    Roles,
 )
-from .core.bus import LoggingMiddleware, MessageBus
-from .core.tracing import Tracer
-from .governance import (
-    BudgetPolicy,
+from .agents.roles import Role, Roles  # noqa: F401
+from .agents.schemas import DebateTranscript, Message  # noqa: F401
+from .core.bus import LoggingMiddleware, MessageBus  # noqa: F401
+from .core.trace import TraceEvent, build_trace, write_trace  # noqa: F401
+from .core.tracing import Tracer  # noqa: F401
+from .governance.governor import (  # noqa: F401
     Decision,
     Governor,
+    PolicyInput,
+    PolicyPatch,
+    apply_patches,
+)
+from .governance.policies import (  # noqa: F401
+    BudgetPolicy,
     LatencySLOPolicy,
     Policy,
     PolicyChecker,
-    PolicyInput,
     PolicyLike,
-    PolicyPatch,
     PolicyResult,
     RiskPolicy,
     SafetyPolicy,
-    apply_patches,
 )
-from .routing import (
+from .routing.model_registry import REGISTRY, ModelInfo, ModelRegistry  # noqa: F401
+from .routing.router import (  # noqa: F401
     BaseTaskSpec,
     ChatTaskSpec,
-    ModelInfo,
-    ModelRegistry,
     ModelRouter,
-    REGISTRY,
     TaskSpec,
     ToolTaskSpec,
 )
 
-__all__ = [
+__all__ = (
     "BudgetPolicy",
     "Decision",
     "DebateOrchestrator",
@@ -73,6 +68,9 @@ __all__ = [
     "TaskSpec",
     "ToolTaskSpec",
     "SafetyPolicy",
+    "TraceEvent",
     "Tracer",
     "apply_patches",
-]
+    "build_trace",
+    "write_trace",
+)


### PR DESCRIPTION
## Summary
- replace the aggregated package imports in `naestro/__init__.py` with direct module re-exports
- rebuild the module docstring and `__all__` tuple to reflect the updated public API surface, including trace helpers

## Testing
- ruff check naestro/__init__.py

------
https://chatgpt.com/codex/tasks/task_b_68ce7044b130832ab397252023c6f7b5