### PR TITLE
Refresh top-level re-exports and helper aliases

### DIFF
--- a/naestro/__init__.py
+++ b/naestro/__init__.py
@@ -1,76 +1,40 @@
-"""Public re-exports for the most frequently used Naestro primitives."""
+"""Convenience re-exports for the primary Naestro building blocks."""
 
 from __future__ import annotations
 
-from .agents.debate import (  # noqa: F401
-    DebateOrchestrator,
-    DebateOutcome,
-    DebateSettings,
-)
-from .agents.roles import Role, Roles  # noqa: F401
-from .agents.schemas import DebateTranscript, Message  # noqa: F401
-from .core.bus import LoggingMiddleware, MessageBus  # noqa: F401
-from .core.trace import TraceEvent, build_trace, write_trace  # noqa: F401
-from .core.tracing import Tracer  # noqa: F401
-from .governance.governor import (  # noqa: F401
-    Decision,
-    Governor,
-    PolicyInput,
-    PolicyPatch,
-    apply_patches,
-)
-from .governance.policies import (  # noqa: F401
+from .agents.debate import DebateConfig, DebateOrchestrator
+from .agents.schemas import AgentMessage, Critique, Verdict
+from .core.bus import MessageBus, logging_mw, redaction_mw
+from .core.trace import start_trace, write_debate_transcript, write_governor
+from .governance.governor import Governor, apply_patches
+from .governance.policies import (
     BudgetPolicy,
     LatencySLOPolicy,
-    Policy,
-    PolicyChecker,
-    PolicyLike,
-    PolicyResult,
     RiskPolicy,
     SafetyPolicy,
 )
-from .routing.model_registry import REGISTRY, ModelInfo, ModelRegistry  # noqa: F401
-from .routing.router import (  # noqa: F401
-    BaseTaskSpec,
-    ChatTaskSpec,
-    ModelRouter,
-    TaskSpec,
-    ToolTaskSpec,
-)
+from .routing.model_registry import ModelInfo
+from .routing.router import ModelRouter, RoutePolicy
 
 __all__ = (
-    "BudgetPolicy",
-    "Decision",
     "DebateOrchestrator",
-    "DebateOutcome",
-    "DebateSettings",
-    "DebateTranscript",
-    "Governor",
-    "LatencySLOPolicy",
-    "LoggingMiddleware",
-    "Message",
+    "DebateConfig",
+    "AgentMessage",
+    "Critique",
+    "Verdict",
     "MessageBus",
-    "BaseTaskSpec",
-    "ChatTaskSpec",
-    "ModelInfo",
-    "ModelRegistry",
-    "ModelRouter",
-    "Policy",
-    "PolicyChecker",
-    "PolicyInput",
-    "PolicyLike",
-    "PolicyPatch",
-    "PolicyResult",
-    "RiskPolicy",
-    "Role",
-    "Roles",
-    "REGISTRY",
-    "TaskSpec",
-    "ToolTaskSpec",
+    "logging_mw",
+    "redaction_mw",
+    "start_trace",
+    "write_debate_transcript",
+    "write_governor",
+    "BudgetPolicy",
     "SafetyPolicy",
-    "TraceEvent",
-    "Tracer",
+    "RiskPolicy",
+    "LatencySLOPolicy",
+    "Governor",
     "apply_patches",
-    "build_trace",
-    "write_trace",
+    "ModelInfo",
+    "ModelRouter",
+    "RoutePolicy",
 )

--- a/naestro/agents/debate.py
+++ b/naestro/agents/debate.py
@@ -24,6 +24,10 @@ class DebateSettings(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
+DebateConfig = DebateSettings
+"""Backward compatible alias for :class:`DebateSettings`."""
+
+
 class DebateOutcome(BaseModel):
     """Result returned after running a debate session."""
 
@@ -116,4 +120,9 @@ class DebateOrchestrator:
             self._tracer.log_event(topic, payload)
 
 
-__all__ = ["DebateOrchestrator", "DebateOutcome", "DebateSettings"]
+__all__ = [
+    "DebateConfig",
+    "DebateOrchestrator",
+    "DebateOutcome",
+    "DebateSettings",
+]

--- a/naestro/agents/schemas.py
+++ b/naestro/agents/schemas.py
@@ -94,4 +94,35 @@ def new_message(
     return Message(role=role, content=content, metadata=meta)
 
 
-__all__ = ["DebateTranscript", "Message", "new_message"]
+AgentMessage = Message
+"""Alias retained for compatibility with earlier agent APIs."""
+
+
+class Critique(BaseModel):
+    """Structured feedback emitted by reviewer or judge agents."""
+
+    message: AgentMessage
+    score: float | None = Field(default=None)
+    notes: str = Field(default="")
+    issues: tuple[str, ...] = Field(default_factory=tuple)
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+
+class Verdict(BaseModel):
+    """Outcome summarising the result of a critique or debate loop."""
+
+    approved: bool
+    rationale: str = Field(default="")
+    confidence: float | None = Field(default=None)
+    critiques: tuple[Critique, ...] = Field(default_factory=tuple)
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+
+__all__ = [
+    "AgentMessage",
+    "Critique",
+    "DebateTranscript",
+    "Message",
+    "Verdict",
+    "new_message",
+]

--- a/naestro/routing/__init__.py
+++ b/naestro/routing/__init__.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from .model_registry import DEFAULT_WEIGHTS, ModelInfo, ModelRegistry, REGISTRY
-from .router import ModelRouter
+from .router import ModelRouter, RoutePolicy
 from .task_specs import BaseTaskSpec, ChatTaskSpec, TaskSpec, ToolTaskSpec
 
 __all__ = [
@@ -13,6 +13,7 @@ __all__ = [
     "ModelInfo",
     "ModelRegistry",
     "ModelRouter",
+    "RoutePolicy",
     "REGISTRY",
     "TaskSpec",
     "ToolTaskSpec",


### PR DESCRIPTION
## Summary
- align naestro.__init__ exports with the latest orchestration, tracing, governance, and routing helpers
- add missing aliases and helper functions so requested symbols are available from their home modules
- extend routing utilities with a RoutePolicy wrapper for simple callable usage

## Testing
- ruff check naestro/__init__.py
- ruff check naestro/agents/schemas.py naestro/core/bus.py naestro/core/trace.py naestro/routing/router.py

------
https://chatgpt.com/codex/tasks/task_b_68ce77c5dab0832a8b396ec81b752047