### PR TITLE
Add role exports to package API

### DIFF
--- a/naestro/__init__.py
+++ b/naestro/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from .agents.debate import DebateConfig, DebateOrchestrator
+from .agents.roles import Role, Roles
 from .agents.schemas import AgentMessage, Critique, Verdict
 from .core.bus import MessageBus, logging_mw, redaction_mw
 from .core.trace import start_trace, write_debate_transcript, write_governor
@@ -19,6 +20,8 @@ from .routing.router import ModelRouter, RoutePolicy
 __all__ = (
     "DebateOrchestrator",
     "DebateConfig",
+    "Role",
+    "Roles",
     "AgentMessage",
     "Critique",
     "Verdict",


### PR DESCRIPTION
## Summary
- re-export Role and Roles from naestro.agents.roles at the package root
- expose Role and Roles in the public __all__ tuple in order after DebateConfig

## Testing
- ruff check naestro/__init__.py

------
https://chatgpt.com/codex/tasks/task_b_68ce7f5dcff4832a8875b48df4d00eff