### PR TITLE
Update CI Python version to 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,11 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.11"
+          python-version: "3.12"
+      - name: Verify Python version
+        run: |
+          python --version
+          python -c "import sys; assert sys.version_info[:2] >= (3, 12)"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
## Summary
- update the CI workflow to install Python 3.12
- add a guard step to assert the configured interpreter is at least Python 3.12

## Testing
- `python --version`
- `python -m pip install --upgrade pip`
- `python -m pip install .[dev]`


------
https://chatgpt.com/codex/tasks/task_b_68ce80dedce8832ab88097f3065afcb2