### PR TITLE
Fix lint issues in governance examples and policies

### DIFF
--- a/examples/governed_pipeline.py
+++ b/examples/governed_pipeline.py
@@ -9,11 +9,24 @@ import yaml
 if __package__ in {None, ""}:
     sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from naestro import Decision, DebateOrchestrator, Message, Policy, PolicyInput, Role, Roles
-from naestro import Governor
+from naestro import (
+    DebateOrchestrator,
+    Decision,
+    Governor,
+    Message,
+    Policy,
+    PolicyInput,
+    Role,
+    Roles,
+)
 
-from packs.trading import DebateGate, ExecutionAgent, RiskAgent, SignalAgent, TradingPipeline
-
+from packs.trading import (
+    DebateGate,
+    ExecutionAgent,
+    RiskAgent,
+    SignalAgent,
+    TradingPipeline,
+)
 
 CONFIG_ROOT = Path(__file__).resolve().parents[1] / "configs"
 TRADING_CONFIG = CONFIG_ROOT / "trading_demo.yaml"
@@ -37,7 +50,11 @@ def build_gate() -> DebateGate:
 
     def analyst(history: Sequence[Message]) -> str:
         confidence = len(history) + 1
-        return f"Approve with confidence {confidence}" if confidence > 1 else "Approve trade"
+        return (
+            f"Approve with confidence {confidence}"
+            if confidence > 1
+            else "Approve trade"
+        )
 
     def risk(history: Sequence[Message]) -> str:
         if any("drawdown" in message.content.lower() for message in history):

--- a/examples/routing_profiles.py
+++ b/examples/routing_profiles.py
@@ -10,8 +10,11 @@ import yaml
 if __package__ in {None, ""}:
     sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from naestro import BaseTaskSpec, ModelInfo, ModelRouter
-
+from naestro import (
+    BaseTaskSpec,
+    ModelInfo,
+    ModelRouter,
+)
 
 CONFIG_PATH = Path(__file__).resolve().parents[1] / "configs" / "router_profiles.yaml"
 

--- a/naestro/core/summary.py
+++ b/naestro/core/summary.py
@@ -28,12 +28,14 @@ class BusSummary:
         parts: list[str] = [f"total={self.total_events}"]
         if self.event_counts:
             event_parts = ", ".join(
-                f"{name}:{count}" for name, count in sorted(self.event_counts.items())
+                f"{name}:{count}"
+                for name, count in sorted(self.event_counts.items())
             )
             parts.append(f"events=({event_parts})")
         if self.redaction_counts:
             redaction_parts = ", ".join(
-                f"{path}:{count}" for path, count in sorted(self.redaction_counts.items())
+                f"{path}:{count}"
+                for path, count in sorted(self.redaction_counts.items())
             )
             parts.append(f"redactions=({redaction_parts})")
         return " | ".join(parts)

--- a/naestro/governance/governor.py
+++ b/naestro/governance/governor.py
@@ -2,22 +2,29 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Mapping, MutableMapping, MutableSequence, Sequence
+from collections.abc import (
+    Iterable,
+    Mapping,
+    MutableMapping,
+    MutableSequence,
+    Sequence,
+)
 from copy import deepcopy
 from typing import Any
 
 from naestro.core.bus import MessageBus
 
 from .policies import PolicyLike
+from .schemas import Decision, PolicyInput, PolicyPatch
 
 
 class _NullBus:
     """Fallback bus used when :mod:`jsonschema` is not available."""
 
-    def publish(self, event: str, payload: Mapping[str, Any]) -> None:  # pragma: no cover - trivial
+    def publish(  # pragma: no cover - trivial
+        self, event: str, payload: Mapping[str, Any]
+    ) -> None:
         return None
-
-from .schemas import Decision, PolicyInput, PolicyPatch
 
 
 def _coerce_input(data: PolicyInput | Mapping[str, Any]) -> PolicyInput:
@@ -62,7 +69,10 @@ class Governor:
         *,
         apply_policy_patches: bool = False,
         return_input: bool = False,
-    ) -> tuple[bool, list[Decision]] | tuple[bool, list[Decision], PolicyInput]:
+    ) -> (
+        tuple[bool, list[Decision]]
+        | tuple[bool, list[Decision], PolicyInput]
+    ):
         policy_input = _coerce_input(data)
         plan = deepcopy(policy_input.plan)
         results: list[Decision] = []
@@ -137,7 +147,9 @@ def _remove(container: Any, key: str | int) -> None:
     container.pop(key, None)
 
 
-def apply_patches(plan: Mapping[str, Any], patches: Iterable[PolicyPatch]) -> dict[str, Any]:
+def apply_patches(
+    plan: Mapping[str, Any], patches: Iterable[PolicyPatch]
+) -> dict[str, Any]:
     """Apply a collection of declarative patches to the supplied plan."""
 
     result: Any = deepcopy(plan)
@@ -149,7 +161,9 @@ def apply_patches(plan: Mapping[str, Any], patches: Iterable[PolicyPatch]) -> di
         value = deepcopy(patch.get("value")) if "value" in patch else None
         current = result
         for segment in path[:-1]:
-            current = _ensure_container(current, segment, create=op in {"set", "merge"})
+            current = _ensure_container(
+                current, segment, create=op in {"set", "merge"}
+            )
         final_segment = path[-1]
         if op == "set":
             _assign(current, final_segment, value)

--- a/naestro/governance/policies.py
+++ b/naestro/governance/policies.py
@@ -7,7 +7,6 @@ from typing import Callable, Protocol
 
 from .schemas import Decision, PolicyInput
 
-
 PolicyResult = Decision
 """Alias maintained for backwards compatibility with earlier releases."""
 
@@ -22,7 +21,9 @@ class PolicyLike(Protocol):
     name: str
     description: str
 
-    def evaluate(self, policy_input: PolicyInput) -> Decision:  # pragma: no cover - protocol method
+    def evaluate(  # pragma: no cover - protocol method
+        self, policy_input: PolicyInput
+    ) -> Decision:
         """Evaluate the provided input and return a policy decision."""
 
 
@@ -43,7 +44,9 @@ class BudgetPolicy:
     """Ensure usage stays within a configured budget."""
 
     name: str = "budget"
-    description: str = "Validate that expected spend does not exceed the available budget."
+    description: str = (
+        "Validate that expected spend does not exceed the available budget."
+    )
 
     def evaluate(self, policy_input: PolicyInput) -> Decision:
         budget = policy_input.budget
@@ -72,8 +75,16 @@ class BudgetPolicy:
         limit_value = float(limit)
         metadata |= {"usage": usage_value, "limit": limit_value}
         if usage_value <= limit_value:
-            reason = f"{usage_value:.2f} {currency} within {limit_value:.2f} {currency} budget"
-            return Decision(name=self.name, passed=True, reason=reason, metadata=metadata)
+            reason = (
+                f"{usage_value:.2f} {currency} within "
+                f"{limit_value:.2f} {currency} budget"
+            )
+            return Decision(
+                name=self.name,
+                passed=True,
+                reason=reason,
+                metadata=metadata,
+            )
         excess = usage_value - limit_value
         metadata["excess"] = excess
         reason = (
@@ -94,12 +105,18 @@ class SafetyPolicy:
     """Check flagged categories against the configured block list."""
 
     name: str = "safety"
-    description: str = "Ensure content moderation checks do not report blocked categories."
+    description: str = (
+        "Ensure content moderation checks do not report blocked categories."
+    )
 
     def evaluate(self, policy_input: PolicyInput) -> Decision:
         safety = policy_input.safety
         if safety is None:
-            return Decision(name=self.name, passed=True, reason="No safety signals provided")
+            return Decision(
+                name=self.name,
+                passed=True,
+                reason="No safety signals provided",
+            )
         blocked = set(safety.blocked_categories)
         flagged = set(safety.flagged_categories)
         violations = sorted(blocked & flagged)
@@ -131,7 +148,9 @@ class RiskPolicy:
     """Validate that the risk score is below an acceptable threshold."""
 
     name: str = "risk"
-    description: str = "Require the risk score to remain under the configured threshold."
+    description: str = (
+        "Require the risk score to remain under the configured threshold."
+    )
     max_score: float | None = None
 
     def evaluate(self, policy_input: PolicyInput) -> Decision:
@@ -174,12 +193,18 @@ class LatencySLOPolicy:
     """Ensure latency measurements remain within an SLO."""
 
     name: str = "latency_slo"
-    description: str = "Validate that observed latency does not exceed the SLO."
+    description: str = (
+        "Validate that observed latency does not exceed the SLO."
+    )
     slo_ms: float | None = None
 
     def evaluate(self, policy_input: PolicyInput) -> Decision:
         latency = policy_input.latency
-        observed = float(latency.value_ms) if latency and latency.value_ms is not None else None
+        observed = (
+            float(latency.value_ms)
+            if latency and latency.value_ms is not None
+            else None
+        )
         slo = (
             float(latency.slo_ms)
             if latency and latency.slo_ms is not None


### PR DESCRIPTION
## Summary
- expand the example trading pipeline imports and wrap the gate response to honour Ruff line-length rules
- reorder and regroup routing profile imports and naestro core summary formatting to satisfy the 88 character constraint
- reflow governor and policy helpers to bring imports, function signatures, and user-facing strings within the configured limits

## Testing
- `ruff check naestro packs examples tests/test_debate_basic.py tests/test_roles_registry.py tests/test_message_bus.py tests/test_governor.py tests/test_router_selection.py tests/packs/trading/test_backtest_smoke.py tests/packs/trading/test_pipeline_debate_gate.py tests/conftest.py tests/training/__init__.py` *(fails: existing lint violations outside the modified files)*

------
https://chatgpt.com/codex/tasks/task_b_68ce856088b8832a87afb9b30cf8a3fe