### PR TITLE
Reorder routing imports

### DIFF
--- a/naestro/routing/__init__.py
+++ b/naestro/routing/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from .model_registry import DEFAULT_WEIGHTS, ModelInfo, ModelRegistry, REGISTRY
+from .model_registry import DEFAULT_WEIGHTS, REGISTRY, ModelInfo, ModelRegistry
 from .router import ModelRouter, RoutePolicy
 from .task_specs import BaseTaskSpec, ChatTaskSpec, TaskSpec, ToolTaskSpec
 


### PR DESCRIPTION
## Summary
- reorder the routing module's relative imports to follow Ruff's configured ordering

## Testing
- ruff check naestro/routing/__init__.py

------
https://chatgpt.com/codex/tasks/task_b_68ce87b30cd0832ab63ecaea980bd72c