### PR TITLE
Fix import grouping in model registry

### DIFF
--- a/naestro/routing/model_registry.py
+++ b/naestro/routing/model_registry.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Dict, Iterable, Iterator, Mapping, Sequence
 
-
 DEFAULT_WEIGHTS: Mapping[str, float] = {
     "quality": 0.6,
     "latency": 0.2,


### PR DESCRIPTION
## Summary
- remove the extra blank line between the standard-library imports and module constants in `model_registry` to satisfy Ruff's sorting rules

## Testing
- ruff check naestro/routing/model_registry.py

------
https://chatgpt.com/codex/tasks/task_b_68ce882e32a0832a924c0224e6a130df