### PR TITLE
Organize typing imports in task specs

### DIFF
--- a/naestro/routing/task_specs.py
+++ b/naestro/routing/task_specs.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
-from typing import Mapping, NotRequired, Sequence, TypedDict
-
+from typing import (
+    Mapping,
+    NotRequired,
+    Sequence,
+    TypedDict,
+)
 
 CapabilityList = Sequence[str] | set[str] | frozenset[str]
 


### PR DESCRIPTION
## Summary
- format the typing imports in `naestro/routing/task_specs.py` in a sorted, multi-line block
- ensure spacing after the `from __future__ import annotations` directive aligns with Ruff formatting

## Testing
- ruff check naestro/routing/task_specs.py

------
https://chatgpt.com/codex/tasks/task_b_68ce88b58954832ab2e4ad4b9add2cb9