### PR TITLE
Reorder imports in debate gate test

### DIFF
--- a/tests/packs/trading/test_pipeline_debate_gate.py
+++ b/tests/packs/trading/test_pipeline_debate_gate.py
@@ -15,6 +15,7 @@ from naestro.agents.debate import DebateOrchestrator
 from naestro.agents.roles import Role, Roles
 from naestro.agents.schemas import Message
 from naestro.core.bus import MessageBus
+
 from packs.trading.agents import TradeDecision
 from packs.trading.pipelines import DebateGate
 


### PR DESCRIPTION
## Summary
- separate the local imports in `tests/packs/trading/test_pipeline_debate_gate.py` so Ruff sees distinct groups

## Testing
- ruff check tests/packs/trading/test_pipeline_debate_gate.py

------
https://chatgpt.com/codex/tasks/task_b_68ce89bfa768832a8c5a8b9bc1afffde