### PR TITLE
Align trading test import order

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,9 @@ target-version = "py312"
 select = ["E", "F", "B", "I"]
 ignore = ["B905"]
 
+[tool.ruff.lint.isort]
+from-first = true
+
 [tool.mypy]
 python_version = "3.12"
 strict = true

--- a/tests/packs/trading/test_backtest_smoke.py
+++ b/tests/packs/trading/test_backtest_smoke.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import sys
 from pathlib import Path
+import sys
 
 import pytest
 

--- a/tests/packs/trading/test_pipeline_debate_gate.py
+++ b/tests/packs/trading/test_pipeline_debate_gate.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-import sys
 from pathlib import Path
 from typing import Sequence
+import sys
 
 if __package__ in {None, ""}:
     sys.path.append(str(Path(__file__).resolve().parents[3]))


### PR DESCRIPTION
## Summary
- alphabetize the standard-library imports in the trading backtest and debate gate tests
- configure Ruff's import sorter to prefer ``from`` imports ahead of plain imports to keep the desired order

## Testing
- `ruff check tests/packs/trading/test_backtest_smoke.py tests/packs/trading/test_pipeline_debate_gate.py`


------
https://chatgpt.com/codex/tasks/task_b_68ce8eeba104832a80f104aaaac049c7