### PR TITLE
Align debate gate imports alphabetically

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ ignore = ["B905"]
 
 [tool.ruff.lint.isort]
 from-first = true
+force-sort-within-sections = true
 
 [tool.mypy]
 python_version = "3.12"

--- a/tests/packs/trading/test_pipeline_debate_gate.py
+++ b/tests/packs/trading/test_pipeline_debate_gate.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Sequence
 import sys
+from typing import Sequence
 
 if __package__ in {None, ""}:
     sys.path.append(str(Path(__file__).resolve().parents[3]))


### PR DESCRIPTION
## Summary
- reorder the debate gate test's standard library imports alphabetically
- configure Ruff's isort settings to force alphabetical sorting within sections

## Testing
- ruff check tests/packs/trading/test_pipeline_debate_gate.py

------
https://chatgpt.com/codex/tasks/task_b_68ce8fe46d78832a80d285370ca0a88a