### PR TITLE
Remove Ruff force sort within sections option

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,6 @@ ignore = ["B905"]
 
 [tool.ruff.lint.isort]
 from-first = true
-force-sort-within-sections = true
 
 [tool.mypy]
 python_version = "3.12"


### PR DESCRIPTION
## Summary
- remove the `force-sort-within-sections = true` override from the Ruff isort configuration so we return to the previous import-order expectations

## Testing
- ruff check naestro packs examples *(reports remaining I001 diagnostics to be addressed separately)*

------
https://chatgpt.com/codex/tasks/task_b_68ce91c0d98c832ab740c23efbf6deec