### PR TITLE
Alphabetize import names per Ruff

### DIFF
--- a/examples/cli.py
+++ b/examples/cli.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import sys
 from pathlib import Path
+import sys
 
 if __package__ in {None, ""}:
     sys.path.append(str(Path(__file__).resolve().parents[1]))

--- a/examples/debate_quickstart.py
+++ b/examples/debate_quickstart.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import sys
 from pathlib import Path
+import sys
 from typing import Sequence
 
 if __package__ in {None, ""}:

--- a/examples/governed_pipeline.py
+++ b/examples/governed_pipeline.py
@@ -1,8 +1,8 @@
 """Execute the trading pipeline with both debate gating and governance."""
 
-import sys
 from pathlib import Path
-from typing import Sequence, cast
+import sys
+from typing import cast, Sequence
 
 import yaml
 

--- a/naestro/__init__.py
+++ b/naestro/__init__.py
@@ -6,11 +6,11 @@ from .agents import DebateSettings, Message
 from .agents.debate import DebateConfig, DebateOrchestrator
 from .agents.roles import Role, Roles
 from .agents.schemas import AgentMessage, Critique, Verdict
-from .core.bus import MessageBus, logging_mw, redaction_mw
+from .core.bus import logging_mw, MessageBus, redaction_mw
 from .core.trace import start_trace, write_debate_transcript, write_governor
 from .core.tracing import Tracer
 from .governance import Decision, Policy, PolicyInput
-from .governance.governor import Governor, apply_patches
+from .governance.governor import apply_patches, Governor
 from .governance.policies import (
     BudgetPolicy,
     LatencySLOPolicy,

--- a/naestro/cli.py
+++ b/naestro/cli.py
@@ -1,5 +1,5 @@
 import argparse
-from typing import Sequence, cast
+from typing import cast, Sequence
 
 from naestro.agents import DebateOrchestrator, DebateSettings, Message, Role, Roles
 from naestro.core.tracing import Tracer

--- a/naestro/core/__init__.py
+++ b/naestro/core/__init__.py
@@ -6,7 +6,7 @@ from .bus import Envelope, LoggingMiddleware, MessageBus, RedactionMiddleware
 from .debate import DebateOrchestrator
 from .schemas import DebateTranscript, Message
 from .summary import BusSummary, summarize
-from .trace import TraceEvent, build_trace, write_trace
+from .trace import build_trace, TraceEvent, write_trace
 from .tracing import Tracer
 
 __all__ = [

--- a/naestro/core/bus.py
+++ b/naestro/core/bus.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-import json
 from contextvars import ContextVar
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from importlib import resources
+import json
 from types import MappingProxyType
 from typing import Any, Callable, Iterable, Mapping, MutableMapping, Protocol, Sequence
 

--- a/naestro/core/debate.py
+++ b/naestro/core/debate.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING, Sequence
+from typing import Sequence, TYPE_CHECKING
 
 from naestro.core.bus import MessageBus
 from naestro.core.schemas import DebateTranscript, Message

--- a/naestro/core/trace.py
+++ b/naestro/core/trace.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-import json
 from dataclasses import dataclass
+import json
 from pathlib import Path
-from typing import TYPE_CHECKING, Iterable, Mapping, Sequence
+from typing import Iterable, Mapping, Sequence, TYPE_CHECKING
 
 from .bus import Envelope
 

--- a/naestro/core/tracing.py
+++ b/naestro/core/tracing.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 import dataclasses
-import json
 from datetime import datetime, timezone
+import json
 from pathlib import Path
 from types import TracebackType
-from typing import Any, Mapping, MutableSequence, cast
+from typing import Any, cast, Mapping, MutableSequence
 
 
 def _coerce(value: object) -> object:

--- a/naestro/governance/__init__.py
+++ b/naestro/governance/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from .governor import Governor, apply_patches
+from .governor import apply_patches, Governor
 from .policies import (
     BudgetPolicy,
     LatencySLOPolicy,

--- a/naestro/routing/__init__.py
+++ b/naestro/routing/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from .model_registry import DEFAULT_WEIGHTS, REGISTRY, ModelInfo, ModelRegistry
+from .model_registry import DEFAULT_WEIGHTS, ModelInfo, ModelRegistry, REGISTRY
 from .router import ModelRouter, RoutePolicy
 from .task_specs import BaseTaskSpec, ChatTaskSpec, TaskSpec, ToolTaskSpec
 

--- a/naestro/routing/router.py
+++ b/naestro/routing/router.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Iterable, Mapping, Sequence, cast
+from typing import Any, cast, Iterable, Mapping, Sequence
 
-from .model_registry import DEFAULT_WEIGHTS, REGISTRY, ModelInfo, ModelRegistry
+from .model_registry import DEFAULT_WEIGHTS, ModelInfo, ModelRegistry, REGISTRY
 from .task_specs import BaseTaskSpec, ChatTaskSpec, TaskSpec, ToolTaskSpec
 
 TaskConfiguration = BaseTaskSpec | TaskSpec | ChatTaskSpec | ToolTaskSpec

--- a/packs/trading/__init__.py
+++ b/packs/trading/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from .agents import ExecutionAgent, RiskAgent, SignalAgent, TradeDecision
 from .backtest import BacktestResult, run_backtest
-from .pipelines import DebateGate, PipelineResult, TradingPipeline, trading_demo
+from .pipelines import DebateGate, PipelineResult, trading_demo, TradingPipeline
 
 __all__ = [
     "BacktestResult",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ ignore = ["B905"]
 [tool.ruff.lint.isort]
 from-first = true
 force-sort-within-sections = true
+order-by-type = false
 
 [tool.mypy]
 python_version = "3.12"


### PR DESCRIPTION
## Summary
- disable type-based isort ordering so Ruff alphabetizes imported names without prioritizing classes
- alphabetize `from ... import ...` statements across Naestro modules, examples, and packs to resolve I001 warnings

## Testing
- `ruff check naestro packs examples`


------
https://chatgpt.com/codex/tasks/task_b_68ce93ffa55c832ab68f134916775af5