### PR TITLE
Fix trading test imports

### DIFF
--- a/tests/packs/trading/test_backtest_smoke.py
+++ b/tests/packs/trading/test_backtest_smoke.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
 
 from pathlib import Path
-from sys import path as sys_path
+import sys
 
 import pytest
 
-if __package__ in {None, ""}:
-    sys_path.append(str(Path(__file__).resolve().parents[3]))
-
-from packs.trading import run_backtest
-from packs.trading.agents import TradeDecision
+try:
+    from packs.trading import run_backtest
+    from packs.trading.agents import TradeDecision
+except Exception:
+    sys.path.append(str(Path(__file__).resolve().parents[3]))
+    from packs.trading import run_backtest
+    from packs.trading.agents import TradeDecision
 
 
 def test_backtest_runs_and_computes_metrics() -> None:


### PR DESCRIPTION
## Summary
- adjust the trading backtest smoke test imports to try normal imports first and fallback to adding the repository root to sys.path if needed

## Testing
- ruff check tests/packs/trading/test_backtest_smoke.py

------
https://chatgpt.com/codex/tasks/task_b_68ceb4b29ae8832a98f0fa20d989d702