### PR TITLE
Fix import sorting for debate gate test

### DIFF
--- a/tests/packs/trading/test_pipeline_debate_gate.py
+++ b/tests/packs/trading/test_pipeline_debate_gate.py
@@ -11,18 +11,15 @@ try:
     from naestro.agents.roles import Role, Roles
     from naestro.agents.schemas import Message
     from naestro.core.bus import MessageBus
-
-    from packs.trading.agents import TradeDecision
-    from packs.trading.pipelines import DebateGate
-except Exception:
+except ModuleNotFoundError:
     sys.path.append(str(Path(__file__).resolve().parents[3]))
     from naestro.agents.debate import DebateOrchestrator
     from naestro.agents.roles import Role, Roles
     from naestro.agents.schemas import Message
     from naestro.core.bus import MessageBus
 
-    from packs.trading.agents import TradeDecision
-    from packs.trading.pipelines import DebateGate
+from packs.trading.agents import TradeDecision
+from packs.trading.pipelines import DebateGate
 
 pytest.importorskip("jsonschema")
 


### PR DESCRIPTION
## Summary
- tighten the import fallback in `tests/packs/trading/test_pipeline_debate_gate.py` to use `ModuleNotFoundError`
- move the trading-pack imports outside of the fallback block so Ruff can treat them as a single sorted group

## Testing
- ruff check --fix tests/packs/trading/test_pipeline_debate_gate.py
- ruff check tests/packs/trading/test_pipeline_debate_gate.py

------
https://chatgpt.com/codex/tasks/task_b_68ceba837fc8832ab8803a168f5cb8d1