### PR TITLE
Adjust import order in debate gate test

### DIFF
--- a/tests/packs/trading/test_pipeline_debate_gate.py
+++ b/tests/packs/trading/test_pipeline_debate_gate.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+import sys  # isort: split
+
 from pathlib import Path
-import sys
 from typing import Sequence
 
 import pytest


### PR DESCRIPTION
## Summary
- move the `sys` import ahead of `pathlib.Path` in the debate gate pipeline test to satisfy the desired stdlib ordering
- add an `isort: split` directive so Ruff keeps the separated import blocks

## Testing
- `ruff check tests/packs/trading/test_pipeline_debate_gate.py`


------
https://chatgpt.com/codex/tasks/task_b_68cebe6ce1e4832abb1fccaaad3a9201