### PR TITLE
Fix debate gate test imports fallback

### DIFF
--- a/tests/packs/trading/test_pipeline_debate_gate.py
+++ b/tests/packs/trading/test_pipeline_debate_gate.py
@@ -8,16 +8,15 @@ from typing import Sequence
 import pytest
 
 try:
-    from naestro.agents.debate import DebateOrchestrator
-    from naestro.agents.roles import Role, Roles
-    from naestro.agents.schemas import Message
-    from naestro.core.bus import MessageBus
+    import naestro  # noqa: F401
 except ModuleNotFoundError:
     sys.path.append(str(Path(__file__).resolve().parents[3]))
-    from naestro.agents.debate import DebateOrchestrator
-    from naestro.agents.roles import Role, Roles
-    from naestro.agents.schemas import Message
-    from naestro.core.bus import MessageBus
+    import naestro  # noqa: F401
+
+from naestro.agents.debate import DebateOrchestrator
+from naestro.agents.roles import Role, Roles
+from naestro.agents.schemas import Message
+from naestro.core.bus import MessageBus
 
 from packs.trading.agents import TradeDecision
 from packs.trading.pipelines import DebateGate


### PR DESCRIPTION
## Summary
- restrict the debate gate test's sys.path fallback to importing `naestro`
- group the `naestro` and trading imports into one contiguous block

## Testing
- `ruff check tests/packs/trading/test_pipeline_debate_gate.py`


------
https://chatgpt.com/codex/tasks/task_b_68cebf85f504832a98c0d4cd16e75c21