### PR TITLE
Fix trading backtest test imports

### DIFF
--- a/tests/packs/trading/test_backtest_smoke.py
+++ b/tests/packs/trading/test_backtest_smoke.py
@@ -6,12 +6,13 @@ import sys
 import pytest
 
 try:
-    from packs.trading import run_backtest
-    from packs.trading.agents import TradeDecision
-except Exception:
+    import packs.trading  # noqa: F401
+except ModuleNotFoundError:
     sys.path.append(str(Path(__file__).resolve().parents[3]))
-    from packs.trading import run_backtest
-    from packs.trading.agents import TradeDecision
+    import packs.trading  # noqa: F401
+
+from packs.trading import run_backtest
+from packs.trading.agents import TradeDecision
 
 
 def test_backtest_runs_and_computes_metrics() -> None:


### PR DESCRIPTION
## Summary
- ensure the trading test only probes for the top-level package before updating `sys.path`
- consolidate the `packs.trading` imports into a single block after the fallback

## Testing
- ruff check tests/packs/trading/test_backtest_smoke.py

------
https://chatgpt.com/codex/tasks/task_b_68cec2b82c08832abc1ca80820c6ec52