### PR TITLE
Fix import sorting for trading pipeline test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ ignore = ["B905"]
 from-first = true
 force-sort-within-sections = true
 order-by-type = false
+known-first-party = ["naestro", "packs", "examples", "tests"]
 
 [tool.mypy]
 python_version = "3.12"

--- a/tests/packs/trading/test_pipeline_debate_gate.py
+++ b/tests/packs/trading/test_pipeline_debate_gate.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-import sys  # isort: split
-
 from pathlib import Path
+import sys
 from typing import Sequence
 
 import pytest
@@ -17,7 +16,6 @@ from naestro.agents.debate import DebateOrchestrator
 from naestro.agents.roles import Role, Roles
 from naestro.agents.schemas import Message
 from naestro.core.bus import MessageBus
-
 from packs.trading.agents import TradeDecision
 from packs.trading.pipelines import DebateGate
 


### PR DESCRIPTION
## Summary
- remove the isort split directive from the trading debate gate test and keep standard-library imports grouped with `sys`
- teach Ruff to treat our packages as first-party so the `naestro` and `packs.trading` imports sort together without a blank line

## Testing
- ruff check tests/packs/trading/test_pipeline_debate_gate.py

------
https://chatgpt.com/codex/tasks/task_b_68cec396bf48832ab51e080c16c99bf8