### PR TITLE
Align first-party import blocks

### DIFF
--- a/examples/governed_pipeline.py
+++ b/examples/governed_pipeline.py
@@ -19,7 +19,6 @@ from naestro import (
     Role,
     Roles,
 )
-
 from packs.trading import (
     DebateGate,
     ExecutionAgent,

--- a/packs/trading/examples/aapl_demo.py
+++ b/packs/trading/examples/aapl_demo.py
@@ -1,5 +1,4 @@
 """Run the TradingAgents demo pipeline with bundled sample data."""
-
 from __future__ import annotations
 
 import csv
@@ -7,7 +6,6 @@ from importlib import resources
 from typing import Sequence
 
 from naestro.agents import DebateOrchestrator, Message, Role, Roles
-
 from packs.trading import DebateGate, trading_demo
 
 


### PR DESCRIPTION
## Summary
- make `examples/governed_pipeline.py` use a single first-party import block for naestro and packs imports
- ensure the trading demo example groups first-party imports together after the future import

## Testing
- ruff check naestro packs examples tests/test_debate_basic.py tests/test_roles_registry.py tests/test_message_bus.py tests/test_governor.py tests/test_router_selection.py tests/packs/trading/test_backtest_smoke.py tests/packs/trading/test_pipeline_debate_gate.py tests/conftest.py tests/training/__init__.py

------
https://chatgpt.com/codex/tasks/task_b_68cec6367584832a8a6faafe4924798a