### PR TITLE
Adjust aapl_demo stdlib import order

### DIFF
--- a/packs/trading/examples/aapl_demo.py
+++ b/packs/trading/examples/aapl_demo.py
@@ -1,9 +1,11 @@
 """Run the TradingAgents demo pipeline with bundled sample data."""
 from __future__ import annotations
 
-import csv
+# isort: off
 from importlib import resources
 from typing import Sequence
+import csv
+# isort: on
 
 from naestro.agents import DebateOrchestrator, Message, Role, Roles
 from packs.trading import DebateGate, trading_demo


### PR DESCRIPTION
## Summary
- group the trading demo's standard-library from-imports ahead of the csv import
- wrap the stdlib import block with isort directives to preserve the desired ordering

## Testing
- ruff check --select I --fix packs/trading/examples/aapl_demo.py
- ruff check naestro packs examples tests/test_debate_basic.py tests/test_roles_registry.py tests/test_message_bus.py tests/test_governor.py tests/test_router_selection.py tests/packs/trading/test_backtest_smoke.py tests/packs/trading/test_pipeline_debate_gate.py tests/conftest.py tests/training/__init__.py

------
https://chatgpt.com/codex/tasks/task_b_68ced97dfc38832a83677129ba2e2f2b