### PR TITLE
Reorder stdlib imports in aapl demo example

### DIFF
--- a/packs/trading/examples/aapl_demo.py
+++ b/packs/trading/examples/aapl_demo.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 # isort: off
 from importlib import resources
 from typing import Sequence
-import csv
 # isort: on
+
+import csv
 
 from naestro.agents import DebateOrchestrator, Message, Role, Roles
 from packs.trading import DebateGate, trading_demo


### PR DESCRIPTION
## Summary
- move the trading example's stdlib `from` imports ahead of the plain `import csv` statement to match the requested order
- confirm no import-sorting violations remain after reorganizing the import block

## Testing
- ruff check --select I --fix packs/trading/examples/aapl_demo.py
- ruff check naestro packs examples tests/test_debate_basic.py tests/test_roles_registry.py tests/test_message_bus.py tests/test_governor.py tests/test_router_selection.py tests/packs/trading/test_backtest_smoke.py tests/packs/trading/test_pipeline_debate_gate.py tests/conftest.py tests/training/__init__.py

------
https://chatgpt.com/codex/tasks/task_b_68cedb0cde84832a8c2152afdc40dfd5