### PR TITLE
Add typing-extensions to dev requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 pytest>=8.2
 pytest-cov>=5.0
 jsonschema>=4.0
+typing-extensions>=4.10
 -r src/gateway/requirements.txt


### PR DESCRIPTION
## Summary
- add an explicit typing-extensions>=4.10 requirement for dev installs

## Testing
- pip install -r requirements-dev.txt
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68ceddf211ac832a8c112d8e5c00d0fa