### PR TITLE
Use typing_extensions for routing task specs

### DIFF
--- a/naestro/routing/task_specs.py
+++ b/naestro/routing/task_specs.py
@@ -2,12 +2,9 @@
 
 from __future__ import annotations
 
-from typing import (
-    Mapping,
-    NotRequired,
-    Sequence,
-)
-from typing_extensions import TypedDict
+from typing import Mapping, Sequence
+
+from typing_extensions import NotRequired, TypedDict
 
 CapabilityList = Sequence[str] | set[str] | frozenset[str]
 


### PR DESCRIPTION
## Summary
- import TypedDict and NotRequired from typing_extensions for routing task specifications
- keep typing module imports limited to Mapping and Sequence

## Testing
- ruff check naestro/routing/task_specs.py
- pytest tests/test_router_selection.py

------
https://chatgpt.com/codex/tasks/task_b_68cee03e5570832a92bd7db72351f7e9