### PR TITLE
chore(ui): regenerate pnpm lockfile

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -47,5 +47,6 @@
     "react-dom": "^19.1.1",
     "recharts": "^3.2.0",
     "socket.io-client": "^4.7.5"
-  }
+  },
+  "packageManager": "pnpm@10.5.2+sha1.ca68c0441df195b7e2992f1d1cb12fb731f82d78"
 }

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -132,6 +132,10 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  '@babel/runtime@7.28.3':
+    resolution: {integrity: sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/runtime@7.28.4':
     resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
     engines: {node: '>=6.9.0'}
@@ -2591,6 +2595,8 @@ snapshots:
     dependencies:
       '@babel/types': 7.28.4
 
+  '@babel/runtime@7.28.3': {}
+
   '@babel/runtime@7.28.4': {}
 
   '@babel/template@7.27.2':
@@ -3162,7 +3168,7 @@ snapshots:
   '@testing-library/dom@10.4.1':
     dependencies:
       '@babel/code-frame': 7.27.1
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.28.3
       '@types/aria-query': 5.0.4
       aria-query: 5.3.0
       dom-accessibility-api: 0.5.16


### PR DESCRIPTION
## Summary
- regenerate the ui pnpm lockfile so the Docker build has a frozen dependency graph
- pin pnpm 10.5.2 in ui/package.json to ensure corepack selects a compatible version inside the image

## Testing
- pnpm test:smoke
- docker build --progress plain -f ui/Dockerfile ui *(fails: `docker` not available in environment)*

------
https://chatgpt.com/codex/tasks/task_b_68cee1584cd0832ab10f1b2ec6720498