### PR TITLE
Fix spacing before start_trace definition

### DIFF
--- a/naestro/core/trace.py
+++ b/naestro/core/trace.py
@@ -63,6 +63,8 @@ def write_trace(
     events = [event.to_dict() for event in build_trace(envelopes)]
     target.write_text(dumps(events, indent=2), encoding="utf-8")
     return target
+
+
 def start_trace(
     *, root: Path | str | None = None, run_name: str | None = None
 ) -> "Tracer":


### PR DESCRIPTION
## Summary
- add the missing blank line between `write_trace` and `start_trace` so the module matches Black's layout expectations

## Testing
- black naestro/core/trace.py

------
https://chatgpt.com/codex/tasks/task_b_68cee413e940832a88501589c1f139a7