### PR TITLE
Fix spacing in aapl_demo example

### DIFF
--- a/packs/trading/examples/aapl_demo.py
+++ b/packs/trading/examples/aapl_demo.py
@@ -1,9 +1,11 @@
 """Run the TradingAgents demo pipeline with bundled sample data."""
+
 from __future__ import annotations
 
 # isort: off
 from importlib import resources
 from typing import Sequence
+
 # isort: on
 
 import csv


### PR DESCRIPTION
## Summary
- insert the required blank line between the module docstring and future import
- reformat the example file with `black`

## Testing
- black packs/trading/examples/aapl_demo.py

------
https://chatgpt.com/codex/tasks/task_b_68cee48776f4832ab4ab67ded18514db