### PR TITLE
Reorder governance schema imports

### DIFF
--- a/naestro/governance/schemas.py
+++ b/naestro/governance/schemas.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from typing import Any, Literal
-from typing_extensions import TypedDict
 
 from pydantic import BaseModel, ConfigDict, Field
+from typing_extensions import TypedDict
 
 
 class BudgetContext(BaseModel):


### PR DESCRIPTION
## Summary
- reorder the governance schemas imports to separate standard library and third-party modules

## Testing
- ruff check naestro/governance/schemas.py --fix
- ruff check naestro packs examples

------
https://chatgpt.com/codex/tasks/task_b_68ceeb721768832ab2760ce126be77d6