### PR TITLE
Ensure forward waits for downstream halt or envelope

### DIFF
--- a/naestro/core/bus.py
+++ b/naestro/core/bus.py
@@ -169,7 +169,7 @@ class Envelope:
         }
 
 
-Forward = Callable[[str, Payload], tuple[str, Payload]]
+Forward = Callable[[str, Payload], tuple[str, Payload] | None]
 
 
 class Middleware(Protocol):
@@ -261,13 +261,18 @@ class MessageBus:
         forward_result: tuple[str, Payload] | None = None
         forward_called = False
 
-        def forward(next_event: str, next_payload: Payload) -> tuple[str, Payload]:
+        def forward(
+            next_event: str, next_payload: Payload
+        ) -> tuple[str, Payload] | None:
             nonlocal forward_called, final_event, final_payload, envelope
             nonlocal forward_result
             forward_called = True
             final_event, final_payload, envelope = self._dispatch(
                 index + 1, next_event, next_payload
             )
+            if envelope is None:
+                forward_result = None
+                return None
             forward_result = (final_event, final_payload)
             return forward_result
 


### PR DESCRIPTION
## Summary
- return `None` from `forward` when downstream dispatch halts so callers wait for a definitive outcome
- extend the `Forward` callable signature to allow `None` and add assertions in middleware tests

## Testing
- pytest tests/test_message_bus.py

------
https://chatgpt.com/codex/tasks/task_b_68ceedda0178832a886d769ca8d0c1ce